### PR TITLE
fix: relationMode default value, hide relation tab in labels/index.vue

### DIFF
--- a/frontend/pages/projects/_id/custom/index.vue
+++ b/frontend/pages/projects/_id/custom/index.vue
@@ -130,8 +130,7 @@ export default {
       rtl: false,
       selectedLabelIndex: null,
       progress: {},
-      relationMode: true,
-      exclusive: false
+      relationMode: false
     }
   },
 

--- a/frontend/pages/projects/_id/labels/index.vue
+++ b/frontend/pages/projects/_id/labels/index.vue
@@ -8,7 +8,7 @@
       <template v-else-if="isCustom">
         <v-tab class="text-capitalize">Category</v-tab>
         <v-tab class="text-capitalize">Span</v-tab>
-        <v-tab class="text-capitalize">Relation</v-tab>
+        <v-tab v-if="project.useRelation" class="text-capitalize">Relation</v-tab>
       </template>
       <template v-else>
         <v-tab class="text-capitalize">Span</v-tab>


### PR DESCRIPTION
Bugs: 
- Relation tab appears in labels/ page even though the "use relation" checkbox wasnt checked
- relationMode default value was set to true

What's changed: 
- frontend/pages/projects/_id/custom/index.vue: deleted unused variable, changed default value of relationMode to false 
- frontend/pages/projects/_id/labels/index.vue: hide the relation tab if the project doesnt use relation

Screenshots: 
![image](https://user-images.githubusercontent.com/12537724/178704269-1beca5c5-cd2a-459b-8fee-98e1e1c9c437.png)

