### PR TITLE
feat: Adjust "Add Member" to search by email

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -5,4 +5,4 @@ from rest_framework import serializers
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
-        fields = ("id", "username", "is_superuser", "is_staff")
+        fields = ("id", "username", "email", "is_superuser", "is_staff")

--- a/frontend/components/member/FormCreate.vue
+++ b/frontend/components/member/FormCreate.vue
@@ -15,13 +15,21 @@
           :loading="isLoading"
           :search-input.sync="username"
           hide-no-data
-          item-text="username"
+          item-text="email"
+          item-value="username"
           :label="$t('members.userSearchAPIs')"
           :placeholder="$t('members.userSearchPrompt')"
           :prepend-icon="mdiAccount"
           :rules="[rules.userRequired]"
           return-object
-        />
+        >
+          <template slot="item" slot-scope="{ item }">
+            <v-list-item-content>
+              <p class="font-weight-bold">{{item.username}}</p>
+              <p>{{item.email}}</p>
+            </v-list-item-content>
+          </template>
+        </v-autocomplete>
         <v-select
           v-model="role"
           :items="roles"
@@ -103,6 +111,7 @@ export default Vue.extend({
         return {
           id: this.value.user,
           username: this.value.username,
+          email: this.value.email,
           isStaff: false
         }
       },

--- a/frontend/domain/models/member/member.ts
+++ b/frontend/domain/models/member/member.ts
@@ -3,6 +3,7 @@ export class MemberItem {
   user: number
   role: number
   username: string
+  email: string
   rolename: string
 
   get isProjectAdmin(): boolean {
@@ -15,6 +16,7 @@ export class MemberItem {
       user: this.user,
       role: this.role,
       username: this.username,
+      email: this.email,
       rolename: this.rolename
     }
   }

--- a/frontend/domain/models/user/user.ts
+++ b/frontend/domain/models/user/user.ts
@@ -3,6 +3,7 @@ import { Expose } from 'class-transformer'
 export class UserItem {
   id: number
   username: string
+  email: string
 
   @Expose({ name: 'is_superuser' })
   isSuperuser: boolean
@@ -14,6 +15,7 @@ export class UserItem {
     return {
       id: this.id,
       username: this.username,
+      email: this.email,
       is_superuser: this.isSuperuser,
       is_staff: this.isStaff
     }

--- a/frontend/i18n/de/projects/members.js
+++ b/frontend/i18n/de/projects/members.js
@@ -4,7 +4,7 @@ export default {
   updateRole: 'Rolle aktualisieren',
   addMember: 'Mitglied hinzufügen',
   userSearchAPIs: 'Nutzer-Such-APIs',
-  userSearchPrompt: 'Tippe, um zu suchen',
+  userSearchPrompt: 'Geben Sie die E-Mail-Adresse des Benutzers ein, um zu suchen',
   removeMember: 'Mitglied entfernen',
   removePrompt: 'Bist du dir sicher, dass du diese Mitglieder entfernen willst?',
   roles: {

--- a/frontend/i18n/en/projects/members.js
+++ b/frontend/i18n/en/projects/members.js
@@ -4,7 +4,7 @@ export default {
   updateRole: 'Update Role',
   addMember: 'Add Member',
   userSearchAPIs: 'User Search APIs',
-  userSearchPrompt: 'Start typing to search',
+  userSearchPrompt: 'Type user\'s email to search',
   removeMember: 'Remove Member',
   removePrompt: 'Are you sure you want to remove these members?',
   roles: {

--- a/frontend/i18n/fr/projects/members.js
+++ b/frontend/i18n/fr/projects/members.js
@@ -4,7 +4,7 @@ export default {
   updateRole: 'Mettre à jour le rôle',
   addMember: 'Ajouter un membre',
   userSearchAPIs: "Rechercher des utilisateurs (avec l'IPA)",
-  userSearchPrompt: 'Commencez à taper pour rechercher',
+  userSearchPrompt: "Tapez l'e-mail de l'utilisateur pour rechercher",
   removeMember: 'Supprimer un membre',
   removePrompt: 'Êtes-vous sûr de vouloir supprimer ces membres ?',
   roles: {

--- a/frontend/i18n/zh/projects/members.js
+++ b/frontend/i18n/zh/projects/members.js
@@ -4,7 +4,7 @@ export default {
   updateRole: '更行角色',
   addMember: '添加成员',
   userSearchAPIs: '用户搜索接口',
-  userSearchPrompt: '开始搜索',
+  userSearchPrompt: '输入用户的电子邮件进行搜索',
   removeMember: '移除成员',
   removePrompt: '你确定要移除当前成员吗?',
   roles: {

--- a/frontend/services/application/member/memberData.ts
+++ b/frontend/services/application/member/memberData.ts
@@ -5,6 +5,7 @@ export class MemberDTO {
   user: number
   role: number
   username: string
+  email: string
   rolename: string
 
   constructor(item: MemberItem) {
@@ -12,6 +13,7 @@ export class MemberDTO {
     this.user = item.user
     this.role = item.role
     this.username = item.username
+    this.email = item.email
     this.rolename = item.rolename
   }
 }

--- a/frontend/services/application/user/userData.ts
+++ b/frontend/services/application/user/userData.ts
@@ -3,11 +3,13 @@ import { UserItem } from '~/domain/models/user/user'
 export class UserDTO {
   id: number
   username: string
+  email: string
   isStaff: boolean
 
   constructor(item: UserItem) {
     this.id = item.id
     this.username = item.username
+    this.email = item.email
     this.isStaff = item.isStaff
   }
 }


### PR DESCRIPTION
This is not directly related with the Keycloak SSO feature. However, I noticed that with the Keycloak SSO feature, there may be an issue for the admin of a doccano project. Since the username generated by Keycloak SSO is based on token, the admin won't be able to know who is the owner of a user account based on username alone. Previously, in the "Add Member" menu of a doccano project, we can only search user by username. This PR proposes so that the "Add Member" menu performs user search by email, and the drop-down list will show both username and email.

Notably, the v-autocomplete element behaves somewhat like a "select" HTML element; the email shown on UI is only on "visual level" (item-text: "email"), whereas the actual value that gets saved is the username (item-value: "username"). In other words, the relationship between project model and user model is still based on username.

What's changed:
 - backend/users/serializers.py : Add email field into user list serializer
 - frontend/components/member/FormCreate.vue : Adjust the v-autocomplete to search by email, add custom drop-down list
 - frontend/domain/models/member/member.ts : Add email to the member model
 - frontend/domain/models/user/user.ts : Add email to the user model
 - frontend/services/application/member/memberData.ts : Add email to the member constructor based on data received from BE
 - frontend/services/application/user/userData.ts : Add email to the user constructor based on data received from BE
 - frontend/i18n/en/projects/members.js : Adjust the english version of the v-autocomplete label in "Add Member"

Screenshots:

Before
<img width="960" alt="before" src="https://user-images.githubusercontent.com/64476430/179949595-2e921bf2-9ad2-4d32-9096-2948109d70e7.png">

After
<img width="960" alt="after1" src="https://user-images.githubusercontent.com/64476430/179949642-97f184ab-47a0-4bf5-a2f3-20bca6a95a9d.png">
<img width="960" alt="after2" src="https://user-images.githubusercontent.com/64476430/179949653-85df89b1-d6be-4608-9481-de32da5e4292.png">
<img width="960" alt="after3" src="https://user-images.githubusercontent.com/64476430/179949656-795bea42-2ed1-4477-b2c6-996b8f990f76.png">
