### PR TITLE
Feat: Data Export Test

### DIFF
--- a/backend/data_export/tests/test_catalog.py
+++ b/backend/data_export/tests/test_catalog.py
@@ -8,6 +8,7 @@ from projects.models import (
     SEQ2SEQ,
     SEQUENCE_LABELING,
     SPEECH2TEXT,
+    ARTICLE_ANNOTATION,
 )
 
 
@@ -20,6 +21,7 @@ class TestOptions(unittest.TestCase):
             SEQ2SEQ,
             SEQUENCE_LABELING,
             SPEECH2TEXT,
+            ARTICLE_ANNOTATION,
         ]
         for task in tasks:
             with self.subTest(task=task):

--- a/backend/data_export/tests/test_task.py
+++ b/backend/data_export/tests/test_task.py
@@ -1,4 +1,3 @@
-from cmath import nan
 import os
 import zipfile
 


### PR DESCRIPTION
What's changed:
- `backend/data_export/tests/test_catalog.py`: added `ArticleAnnotation` project to test catalog
- `backend/data_export/tests/test_task.py`: added new test tasks for data export of ArticleAnnotation Project and Custom Relation Extraction