### PR TITLE
feat: Make article annotation view to navigate through article elements in order

### DIFF
--- a/backend/examples/views/example.py
+++ b/backend/examples/views/example.py
@@ -35,7 +35,10 @@ class ExampleList(generics.ListCreateAPIView):
             value = random.randrange(2, 20)
             queryset = queryset.annotate(sort_id=F("id") % value).order_by("sort_id", "id")
         else:
-            queryset = queryset.order_by("created_at")
+            if self.project.is_article_project:
+                queryset = queryset.order_by("article_id", "order")
+            else:
+                queryset = queryset.order_by("created_at")
         return queryset
 
     def perform_create(self, serializer):

--- a/frontend/pages/projects/_id/article-annotation/index.vue
+++ b/frontend/pages/projects/_id/article-annotation/index.vue
@@ -21,6 +21,7 @@
         </v-btn-toggle>
       </toolbar-laptop>
       <toolbar-mobile :total="docs.count" class="d-flex d-sm-none" />
+      <h3 class="mt-3">Article Title: {{ doc.meta.meta.article_title }}</h3>
     </template>
     <template #content>
       <v-card v-shortkey="shortKeysCategory" @shortkey="addOrRemoveCategory">


### PR DESCRIPTION
This PR performs 2 things: (1) Make the navigation buttons on article annotation view page to move through article elements in order, (2) Add article title to the top of the article annotation view page. Notably, I've found that dealing with the navigation is much easier and more practical from the BE side.

What's changed:
 - backend/examples/views/example.py : Check if the current project is of article annotation type, if yes then the returned list of texts is sorted by `article_id` and `order` (and if not of article annotation type, it will behave like originally which sorts the list of texts by `created_at`). This effectively makes navigation on the FE side to move through one article's elements before going to a different article.
 - frontend/pages/projects/_id/article-annotation/index.vue : This file is based on the one in #19, with just an addition on line 24 to show the current article's title information on the top of the annotation box.

Notable:
 - I assume in most/all cases we don't want to enable the "randomize document order" feature. When enabled, it will still use the original randomization mechanism (code is also in backend/examples/views/example.py) which divides the `id` by a random number and sort the texts based on this value. So, currently, if article annotation project enables the "randomize document order" feature, the texts sequence will be random without regards to `article_id` and `order`.
<img width="960" alt="note1_random_order" src="https://user-images.githubusercontent.com/64476430/190614593-32a18618-5c56-4033-b8b2-d1f7659a1184.png">

Screenshots:
For example, let's import a JSON file that actually contains two articles but the elements are not ordered.
<img width="960" alt="note2_article_import_order" src="https://user-images.githubusercontent.com/64476430/190614630-9b487a59-aa2d-47c3-b6f6-efa7bfac1514.png">

Navigation is working through same article's elements before going to a different article (click on the link to see the video recording).
https://user-images.githubusercontent.com/64476430/190615634-ae137e50-8c74-444d-b05a-511c955af412.mp4

Article's title information shown on the top of the annotation box.
<img width="960" alt="note5_title" src="https://user-images.githubusercontent.com/64476430/190615470-d02d3999-5c95-49f3-8bc8-b44b0275cbde.png">
