### PR TITLE
feat: Add article count to navigation bar

### DIFF
--- a/backend/examples/serializers.py
+++ b/backend/examples/serializers.py
@@ -52,6 +52,16 @@ class ExampleSerializer(serializers.ModelSerializer):
         read_only_fields = ["filename", "is_confirmed", "upload_name"]
 
 
+class ExampleArticleIdSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Example
+        fields = [
+            "id",
+            "article_id"
+        ]
+        read_only_fields = ["article_id"]
+
+
 class ExampleStateSerializer(serializers.ModelSerializer):
     class Meta:
         model = ExampleState

--- a/backend/examples/urls.py
+++ b/backend/examples/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from .views.example import ExampleArticleIdList
 from .views.comment import CommentDetail, CommentList
 from .views.example import ExampleDetail, ExampleList
 from .views.example_state import ExampleStateList
@@ -10,4 +11,5 @@ urlpatterns = [
     path(route="comments", view=CommentList.as_view(), name="comment_list"),
     path(route="comments/<int:comment_id>", view=CommentDetail.as_view(), name="comment_detail"),
     path(route="examples/<int:example_id>/states", view=ExampleStateList.as_view(), name="example_state_list"),
+    path(route="article_ids", view=ExampleArticleIdList.as_view(), name="article_id_list"),
 ]

--- a/backend/examples/views/example.py
+++ b/backend/examples/views/example.py
@@ -1,6 +1,6 @@
 import random
 
-from django.db.models import F, Count
+from django.db.models import F
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, generics, status

--- a/frontend/components/tasks/toolbar/ToolbarLaptop.vue
+++ b/frontend/components/tasks/toolbar/ToolbarLaptop.vue
@@ -42,6 +42,9 @@
       <button-pagination
         :value="page"
         :total="total"
+        :is-article-project="isArticleProject"
+        :article-index="articleIndex"
+        :article-total="articleTotal"
         @click:prev="updatePage(page - 1)"
         @click:next="updatePage(page + 1)"
         @click:first="updatePage(1)"
@@ -103,6 +106,21 @@ export default Vue.extend({
     total: {
       type: Number,
       default: 1
+    },
+    isArticleProject: {
+      type: Boolean,
+      default: false,
+      required: false
+    },
+    articleIndex: {
+      type: Number,
+      default: 1,
+      required: false
+    },
+    articleTotal: {
+      type: Number,
+      default: 1,
+      required: false
     }
   },
 

--- a/frontend/components/tasks/toolbar/buttons/ButtonPagination.vue
+++ b/frontend/components/tasks/toolbar/buttons/ButtonPagination.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="v-data-footer">
     <v-edit-dialog large persistent @save="changePageNumber">
-      <span>{{ value }} of {{ total }}</span>
+      <span v-if="isArticleProject">
+        {{ value }} of {{ total }} texts,
+        {{ articleIndex }} of {{ articleTotal }} articles
+      </span>
+      <span v-else>{{ value }} of {{ total }}</span>
       <template #input>
         <div class="mt-4 title">Move Page</div>
         <v-text-field
@@ -76,6 +80,21 @@ export default Vue.extend({
       type: Number,
       default: 1,
       required: true
+    },
+    isArticleProject: {
+      type: Boolean,
+      default: false,
+      required: false
+    },
+    articleIndex: {
+      type: Number,
+      default: 1,
+      required: false
+    },
+    articleTotal: {
+      type: Number,
+      default: 1,
+      required: false
     }
   },
 

--- a/frontend/domain/models/example/exampleRepository.ts
+++ b/frontend/domain/models/example/exampleRepository.ts
@@ -5,7 +5,7 @@ export type SearchOption = { [key: string]: string | (string | null)[] }
 export interface ExampleRepository {
   list(projectId: string, { limit, offset, q, isChecked }: SearchOption): Promise<ExampleItemList>
 
-  articleIds(projectId: string): Promise<Array<string>>
+  articleIds(projectId: string, limit: string): Promise<Array<string>>
 
   create(projectId: string, item: ExampleItem): Promise<ExampleItem>
 

--- a/frontend/domain/models/example/exampleRepository.ts
+++ b/frontend/domain/models/example/exampleRepository.ts
@@ -5,6 +5,8 @@ export type SearchOption = { [key: string]: string | (string | null)[] }
 export interface ExampleRepository {
   list(projectId: string, { limit, offset, q, isChecked }: SearchOption): Promise<ExampleItemList>
 
+  articleIds(projectId: string): Promise<Array<string>>
+
   create(projectId: string, item: ExampleItem): Promise<ExampleItem>
 
   update(projectId: string, item: ExampleItem): Promise<ExampleItem>

--- a/frontend/pages/projects/_id/article-annotation/index.vue
+++ b/frontend/pages/projects/_id/article-annotation/index.vue
@@ -191,20 +191,14 @@ export default {
     await this.list(doc.id)
 
     this.currentArticleId = doc.articleId
-    const allTexts = await this.$services.example.fetchAll(
+    this.currentWholeArticle = await this.$services.example.fetchAll(
       this.projectId,
-      this.$route.query.q,
+      this.currentArticleId,
       this.$route.query.isChecked
     )
-    const allArticleIds = []
-    for(let i = 0; i < allTexts.items.length; i++) {
-      if(allTexts.items[i].articleId === this.currentArticleId) {
-        this.currentWholeArticle.push(allTexts.items[i])
-      }
-      if(!allArticleIds.includes(allTexts.items[i].articleId)) {
-        allArticleIds.push(allTexts.items[i].articleId)
-      }
-    }
+    const allArticleIds = await this.$services.example.fetchArticleIds(
+      this.projectId
+    )
     this.articleTotal = allArticleIds.length
     this.articleIndex = allArticleIds.indexOf(this.currentArticleId) + 1
   },

--- a/frontend/pages/projects/_id/article-annotation/index.vue
+++ b/frontend/pages/projects/_id/article-annotation/index.vue
@@ -21,50 +21,61 @@
         </v-btn-toggle>
       </toolbar-laptop>
       <toolbar-mobile :total="docs.count" class="d-flex d-sm-none" />
-      <h3 class="mt-3">Article Title: {{ doc.meta.meta.article_title }}</h3>
     </template>
     <template #content>
-      <v-card v-shortkey="shortKeysCategory" @shortkey="addOrRemoveCategory">
-        <v-card-title>
-            <label-group
-              v-if="labelOption === 0"
-              :labels="categoryTypes"
-              :annotations="categories"
-              :single-label="project.singleClassClassification"
-              @add="addCategory"
-              @remove="removeCategory"
-            />
-            <label-select
-              v-else
-              :labels="categoryTypes"
-              :annotations="categories"
-              :single-label="project.singleClassClassification"
-              @add="addCategory"
-              @remove="removeCategory"
-            />
-        </v-card-title>
-        <div class="annotation-text pa-4">
-          <entity-editor
-            :dark="$vuetify.theme.dark"
-            :rtl="isRTL"
-            :text="doc.text"
-            :entities="spans"
-            :entity-labels="spanTypes"
-            :relations="relations"
-            :relation-labels="relationTypes"
-            :allow-overlapping="project.allowOverlapping"
-            :grapheme-mode="project.graphemeMode"
-            :selected-label="selectedLabel"
-            :relation-mode="relationMode"
-            @addEntity="addSpan"
-            @addRelation="addRelation"
-            @click:entity="updateSpan"
-            @click:relation="updateRelation"
-            @contextmenu:entity="deleteSpan"
-            @contextmenu:relation="deleteRelation"
-          />
-        </div>
-      </v-card>
+      <div>
+        <v-row class="mt-3" no-gutters>
+          <v-col cols="6">
+            <div>Whole Article View Here</div>
+            <h3 class="mt-3">Article Title: {{ doc.meta.meta.article_title }}</h3>
+            <p class="my-0">Article ID: {{ currentArticleId }}</p>
+            <div>{{ currentWholeArticleView }}</div>
+          </v-col>
+          <v-col cols="6">
+            <v-card v-shortkey="shortKeysCategory" @shortkey="addOrRemoveCategory">
+              <v-card-title>
+                  <label-group
+                    v-if="labelOption === 0"
+                    :labels="categoryTypes"
+                    :annotations="categories"
+                    :single-label="project.singleClassClassification"
+                    @add="addCategory"
+                    @remove="removeCategory"
+                  />
+                  <label-select
+                    v-else
+                    :labels="categoryTypes"
+                    :annotations="categories"
+                    :single-label="project.singleClassClassification"
+                    @add="addCategory"
+                    @remove="removeCategory"
+                  />
+              </v-card-title>
+              <div class="annotation-text pa-4">
+                <entity-editor
+                  :dark="$vuetify.theme.dark"
+                  :rtl="isRTL"
+                  :text="doc.text"
+                  :entities="spans"
+                  :entity-labels="spanTypes"
+                  :relations="relations"
+                  :relation-labels="relationTypes"
+                  :allow-overlapping="project.allowOverlapping"
+                  :grapheme-mode="project.graphemeMode"
+                  :selected-label="selectedLabel"
+                  :relation-mode="relationMode"
+                  @addEntity="addSpan"
+                  @addRelation="addRelation"
+                  @click:entity="updateSpan"
+                  @click:relation="updateRelation"
+                  @contextmenu:entity="deleteSpan"
+                  @contextmenu:relation="deleteRelation"
+                />
+              </div>
+            </v-card>
+          </v-col>
+        </v-row>
+      </div>
     </template>
     <template #sidebar>
       <annotation-progress :progress="progress" />
@@ -153,7 +164,9 @@ export default {
       rtl: false,
       selectedLabelIndex: null,
       progress: {},
-      relationMode: false
+      relationMode: false,
+      currentArticleId: "",
+      currentWholeArticle: []
     }
   },
 
@@ -169,6 +182,18 @@ export default {
       await this.autoLabel(doc.id)
     }
     await this.list(doc.id)
+
+    this.currentArticleId = doc.articleId
+    const allTexts = await this.$services.example.fetchAll(
+      this.projectId,
+      this.$route.query.q,
+      this.$route.query.isChecked
+    )
+    for(let i = 0; i < allTexts.items.length; i++) {
+      if(allTexts.items[i].articleId === this.currentArticleId) {
+        this.currentWholeArticle.push(allTexts.items[i])
+      }
+    }
   },
 
   computed: {
@@ -217,6 +242,11 @@ export default {
       } else {
         return this.spanTypes
       }
+    },
+
+    currentWholeArticleView() {
+      console.log(JSON.stringify(this.currentWholeArticle))
+      return JSON.stringify(this.currentWholeArticle)
     }
   },
 
@@ -370,7 +400,7 @@ export default {
 
 <style scoped>
 .annotation-text {
-  font-size: 1.25rem !important;
+  font-size: 1.1rem !important;
   font-weight: 500;
   line-height: 2rem;
   font-family: 'Roboto', sans-serif !important;

--- a/frontend/pages/projects/_id/article-annotation/index.vue
+++ b/frontend/pages/projects/_id/article-annotation/index.vue
@@ -191,13 +191,15 @@ export default {
     await this.list(doc.id)
 
     this.currentArticleId = doc.articleId
-    this.currentWholeArticle = await this.$services.example.fetchAll(
+    this.currentWholeArticle = await this.$services.example.fetchByLimit(
       this.projectId,
+      this.docs.count.toString(),
       this.currentArticleId,
       this.$route.query.isChecked
     )
     const allArticleIds = await this.$services.example.fetchArticleIds(
-      this.projectId
+      this.projectId,
+      this.docs.count.toString()
     )
     this.articleTotal = allArticleIds.length
     this.articleIndex = allArticleIds.indexOf(this.currentArticleId) + 1

--- a/frontend/pages/projects/_id/article-annotation/index.vue
+++ b/frontend/pages/projects/_id/article-annotation/index.vue
@@ -7,6 +7,9 @@
         :guideline-text="project.guideline"
         :is-reviewd="doc.isConfirmed"
         :total="docs.count"
+        :is-article-project="true"
+        :article-index="articleIndex"
+        :article-total="articleTotal"
         class="d-none d-sm-block"
         @click:clear-label="clear"
         @click:review="confirm"
@@ -26,10 +29,12 @@
       <div>
         <v-row class="mt-3" no-gutters>
           <v-col cols="6">
-            <div>Whole Article View Here</div>
-            <h3 class="mt-3">Article Title: {{ doc.meta.meta.article_title }}</h3>
-            <p class="my-0">Article ID: {{ currentArticleId }}</p>
-            <div>{{ currentWholeArticleView }}</div>
+            <div id="viewer_component_placeholder" style="overflow-wrap: break-word;">
+              <h3 class="mt-3">Whole Article Viewer Component Here</h3>
+              <h3 class="mt-3">Article Title: {{ doc.meta.meta.article_title }}</h3>
+              <p class="mt-3">Article ID: {{ currentArticleId }}</p>
+              <p class="mt-3">{{ currentWholeArticleView }}</p>
+            </div>
           </v-col>
           <v-col cols="6">
             <v-card v-shortkey="shortKeysCategory" @shortkey="addOrRemoveCategory">
@@ -165,6 +170,8 @@ export default {
       selectedLabelIndex: null,
       progress: {},
       relationMode: false,
+      articleTotal: 1,
+      articleIndex: 1,
       currentArticleId: "",
       currentWholeArticle: []
     }
@@ -189,11 +196,17 @@ export default {
       this.$route.query.q,
       this.$route.query.isChecked
     )
+    const allArticleIds = []
     for(let i = 0; i < allTexts.items.length; i++) {
       if(allTexts.items[i].articleId === this.currentArticleId) {
         this.currentWholeArticle.push(allTexts.items[i])
       }
+      if(!allArticleIds.includes(allTexts.items[i].articleId)) {
+        allArticleIds.push(allTexts.items[i].articleId)
+      }
     }
+    this.articleTotal = allArticleIds.length
+    this.articleIndex = allArticleIds.indexOf(this.currentArticleId) + 1
   },
 
   computed: {
@@ -245,7 +258,6 @@ export default {
     },
 
     currentWholeArticleView() {
-      console.log(JSON.stringify(this.currentWholeArticle))
       return JSON.stringify(this.currentWholeArticle)
     }
   },

--- a/frontend/repositories/example/apiDocumentRepository.ts
+++ b/frontend/repositories/example/apiDocumentRepository.ts
@@ -15,8 +15,8 @@ export class APIExampleRepository implements ExampleRepository {
     return plainToInstance(ExampleItemList, response.data)
   }
 
-  async articleIds(projectId: string): Promise<Array<string>> {
-    const url = `/projects/${projectId}/article_ids?limit=999999=&offset=0`
+  async articleIds(projectId: string, limit = '999999'): Promise<Array<string>> {
+    const url = `/projects/${projectId}/article_ids?limit=${limit}=&offset=0`
     const response = await this.request.get(url)
     return response.data.results.map((i: any) => i.article_id)
   }

--- a/frontend/repositories/example/apiDocumentRepository.ts
+++ b/frontend/repositories/example/apiDocumentRepository.ts
@@ -15,6 +15,12 @@ export class APIExampleRepository implements ExampleRepository {
     return plainToInstance(ExampleItemList, response.data)
   }
 
+  async articleIds(projectId: string): Promise<Array<string>> {
+    const url = `/projects/${projectId}/article_ids?limit=999999=&offset=0`
+    const response = await this.request.get(url)
+    return response.data.results.map((i: any) => i.article_id)
+  }
+
   async create(projectId: string, item: ExampleItem): Promise<ExampleItem> {
     const url = `/projects/${projectId}/examples`
     const response = await this.request.post(url, item.toObject())

--- a/frontend/services/application/example/exampleApplicationService.ts
+++ b/frontend/services/application/example/exampleApplicationService.ts
@@ -31,13 +31,14 @@ export class ExampleApplicationService {
     return await this.list(projectId, options)
   }
 
-  public async fetchAll(
+  public async fetchByLimit(
     projectId: string,
+    count: string,
     q: string,
     isChecked: string
   ): Promise<ExampleListDTO> {
     const options: SearchOption = {
-      limit: '10000',
+      limit: count,
       offset: '0',
       q,
       isChecked
@@ -45,9 +46,9 @@ export class ExampleApplicationService {
     return await this.list(projectId, options)
   }
 
-  public async fetchArticleIds(projectId: string): Promise<Array<string>> {
+  public async fetchArticleIds(projectId: string, count: string): Promise<Array<string>> {
     try {
-      const item = await this.repository.articleIds(projectId)
+      const item = await this.repository.articleIds(projectId, count)
       return item
     } catch (e: any) {
       throw new Error(e.response.data.detail)

--- a/frontend/services/application/example/exampleApplicationService.ts
+++ b/frontend/services/application/example/exampleApplicationService.ts
@@ -37,10 +37,21 @@ export class ExampleApplicationService {
     isChecked: string
   ): Promise<ExampleListDTO> {
     const options: SearchOption = {
+      limit: '10000',
+      offset: '0',
       q,
       isChecked
     }
     return await this.list(projectId, options)
+  }
+
+  public async fetchArticleIds(projectId: string): Promise<Array<string>> {
+    try {
+      const item = await this.repository.articleIds(projectId)
+      return item
+    } catch (e: any) {
+      throw new Error(e.response.data.detail)
+    }
   }
 
   public async create(projectId: string, item: ExampleDTO): Promise<ExampleDTO> {

--- a/frontend/services/application/example/exampleApplicationService.ts
+++ b/frontend/services/application/example/exampleApplicationService.ts
@@ -31,6 +31,18 @@ export class ExampleApplicationService {
     return await this.list(projectId, options)
   }
 
+  public async fetchAll(
+    projectId: string,
+    q: string,
+    isChecked: string
+  ): Promise<ExampleListDTO> {
+    const options: SearchOption = {
+      q,
+      isChecked
+    }
+    return await this.list(projectId, options)
+  }
+
   public async create(projectId: string, item: ExampleDTO): Promise<ExampleDTO> {
     try {
       const doc = this.toModel(item)


### PR DESCRIPTION
This PR primarily aims to add the article count to the navigation bar in article annotation project. In addition, a placeholder for the left-side component is also added and later should be replaced with the real component.

What's changed:

Backend:
 - backend/examples/urls.py : Add the api endpoint url for getting a list of unique article ids, which on FE is used to get total article count and check the place of the currently annotated article (i.e. x of y articles). Previously I used the existing api endpoint for this purpose but I'm worried that retrieving unnecessary columns may degrade the performance when we have thousands of data. Notably, though, the existing api endpoint can already be used for retrieving texts of a specific article id, we just need to add `article_id` into the `search_fields`.
 - backend/examples/serializers.py : Add a data serializer for the article id list.
 - backend/examples/views/example.py : (1) Add `article_id` into the `search_fields` of `ExampleList`. (2) Add the view class for the article id list.

Frontend:
 - frontend/components/tasks/toolbar/buttons/ButtonPagination.vue : Add `isArticleProject`, `articleIndex`, and `articleTotal` props which are used when the current project is article annotation project, and also conditionally select the span to use based on `isArticleProject` value.
 - frontend/components/tasks/toolbar/ToolbarLaptop.vue : Add `isArticleProject`, `articleIndex`, and `articleTotal` props, so that it can pass these values into `<button-pagination>`.
 - frontend/domain/models/example/exampleRepository.ts : Add `articleIds` interface.
 - frontend/repositories/example/apiDocumentRepository.ts : Implement `articleIds` interface, which makes a request to the article id list endpoint.
 - frontend/services/application/example/exampleApplicationService.ts : (1) Add `fetchByLimit()` method for retrieving all texts of a particular article id, notably we can search by article id by passing it into the `q` parameter. (2) Add `fetchArticleIds()` method for retrieving a list of unique article ids.
 - frontend/pages/projects/_id/article-annotation/index.vue : (1) Add a placeholder for left-side article viewer component. (2) Use `fetchByLimit()` to load current article into the placeholder. (3) Use `fetchArticleIds()` to retrieve list of unique article ids and calculate the "x of y articles".

Notable:
 - Currently, BE always sets a default limit of the query to 5 even if FE doesn't set the limit (backend/config/settings/base.py). So, except if we remove the default limit on BE (which I don't think is a good idea), FE must always specify a limit in the query. At the same time, one article can have up to thousands elements (most of them come from comments). That is why on FE in fetchAll() method I set the limit to 10,000 (I think it gives more than enough room for articles with lots of comments), and in fetchArticleIds() method I set the fixed limit to 999,999 (I think even after the dataset grows it will take forever to reach 999,999 unique articles).

Edit:
 - fetchAll() renamed into fetchByLimit()
 - the `limit` parameter for fetchByLimit() and fetchArticleIds() are now based on `count`, which is the total number of texts

Screenshots:
<img width="960" alt="111" src="https://user-images.githubusercontent.com/64476430/191200562-4d97e9b6-6afb-4ec8-a6b9-87cdffd6c6d0.PNG">
<img width="960" alt="222" src="https://user-images.githubusercontent.com/64476430/191200569-b67815b4-f350-4062-8462-253de24f25c9.PNG">
