### PR TITLE
fix: Add default values for null query.q and query.isChecked

### DIFF
--- a/frontend/components/example/ArticleList.vue
+++ b/frontend/components/example/ArticleList.vue
@@ -109,7 +109,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      search: this.$route.query.q,
+      search: this.$route.query.q || '',
       options: {} as DataOptions,
       selectedArticleItems: [] as ExampleArticleDTO[],
       selectedChildArticleItems: [] as ExampleDTO[],

--- a/frontend/components/tasks/toolbar/ToolbarLaptop.vue
+++ b/frontend/components/tasks/toolbar/ToolbarLaptop.vue
@@ -141,7 +141,7 @@ export default Vue.extend({
     },
     filterOption(): string {
       // @ts-ignore
-      return this.$route.query.isChecked
+      return this.$route.query.isChecked || ''
     }
   },
 
@@ -151,7 +151,7 @@ export default Vue.extend({
         query: {
           page: page.toString(),
           isChecked: this.filterOption,
-          q: this.$route.query.q
+          q: this.$route.query.q || ''
         }
       })
     },
@@ -161,7 +161,7 @@ export default Vue.extend({
         query: {
           page: '1',
           isChecked,
-          q: this.$route.query.q
+          q: this.$route.query.q || ''
         }
       })
     },

--- a/frontend/pages/projects/_id/article-annotation/index.vue
+++ b/frontend/pages/projects/_id/article-annotation/index.vue
@@ -162,7 +162,10 @@ export default {
   layout: 'workspace',
 
   validate({ params, query }) {
-    return /^\d+$/.test(params.id) && /^\d+$/.test(query.page)
+    return (
+      /^\d+$/.test(params.id) && /^\d+$/.test(query.page) &&
+      (typeof query.q === 'undefined' || query.q !== null)
+    )
   },
 
   data() {

--- a/frontend/pages/projects/_id/article-annotation/index.vue
+++ b/frontend/pages/projects/_id/article-annotation/index.vue
@@ -162,10 +162,7 @@ export default {
   layout: 'workspace',
 
   validate({ params, query }) {
-    return (
-      /^\d+$/.test(params.id) && /^\d+$/.test(query.page) &&
-      (typeof query.q === 'undefined' || query.q !== null)
-    )
+    return /^\d+$/.test(params.id) && /^\d+$/.test(query.page)
   },
 
   data() {
@@ -194,11 +191,13 @@ export default {
   },
 
   async fetch() {
+    const query = this.$route.query.q || ''
+    const isChecked = this.$route.query.isChecked || ''
     this.docs = await this.$services.example.fetchOne(
       this.projectId,
       this.$route.query.page,
-      this.$route.query.q,
-      this.$route.query.isChecked
+      query,
+      isChecked
     )
     const doc = this.docs.items[0]
     if (this.enableAutoLabeling && !doc.isConfirmed) {
@@ -211,7 +210,7 @@ export default {
       this.projectId,
       this.docs.count.toString(),
       this.currentArticleId,
-      this.$route.query.isChecked
+      isChecked
     )
     this.currentWholeArticle.items = _.orderBy(this.currentWholeArticle.items, 'order')
     const allArticleIds = await this.$services.example.fetchArticleIds(


### PR DESCRIPTION
This PR aims to provide a workaround to the issue that happens when user refreshes the annotation page, which leads to the wrong text being loaded & highlighted and the whole article viewer not in sync with the navigation.

Screenshot of the issue:
<img width="960" alt="bug" src="https://user-images.githubusercontent.com/64476430/193304572-1d8afe39-1b9f-4eaa-9d0f-af5ee1877396.png">

Notably, this issue only happens if we do annotation via clicking the primary "Start Annotation" button on the top-left side. This button is "state-aware" because it will go to the last text previously being annotated by the user. This issue does not happen if we do annotation by clicking the button in the "Dataset" menu on the right side of each text/article entry, which is not state-aware because it simply goes to the associated text.

To solve this issue, I initially tried to implement `beforeUnload` event listener and force the browser to navigate to the correct url with the correct url queries instead of reloading. Unfortunately, it does not work because the browser will keep performing the reload no matter what.

So, I finally decided that we should just show an error when the user refreshes the page during state-aware annotation. Showing an error is "safer" compared to leaving the faulty annotation page as-is, because there is a possibility that the user will continue annotating and maybe it will lead to a mess of miss-match between texts and annotations.

This fix adds an additional check into the `validate()` function. Initially, it only checks `query.page`, which is the "page" query in the url. Now, it also checks `query.q`, which is the "q" query in the url. It returns true if `query.q` is undefined (which is the case when we are annotating via the button in the Dataset menu, and returns false if `query.q` is null (which is the case that happens when we refresh the page during state-aware annotation).

This fix effectively only affects the reloading behavior when the annotation page is reached via the "state-aware" button on the top-left side, and it will not affect the reloading behavior when the annotation page is reached via the button in the Dataset menu. In my opinion, this is a safe temporary solution until a better solution (if any) can be implemented.

Screenshot of the "state-aware" annotation page after reloading:
<img width="960" alt="fix1" src="https://user-images.githubusercontent.com/64476430/193307713-6de8ab25-0cd3-4b21-a157-487f4dcc52fa.PNG">
