### PR TITLE
Feat: New option for export data - group by article_id

### DIFF
--- a/backend/data_export/pipeline/catalog.py
+++ b/backend/data_export/pipeline/catalog.py
@@ -42,6 +42,10 @@ class JSONL(Format):
     name = "JSONL"
 
 
+class JSONArticle(Format):
+    name = "JSONArticle"
+
+
 class Options:
     options: Dict[str, List] = defaultdict(list)
 
@@ -107,3 +111,4 @@ Options.register(ARTICLE_ANNOTATION, JSONL, ARTICLE_ANNOTATION_DIR / "relation_e
 AFFECTIVE_ANNOTATION_DIR = EXAMPLE_DIR / "affective_annotation"
 Options.register(AFFECTIVE_ANNOTATION, JSON, AFFECTIVE_ANNOTATION_DIR / "example.json")
 Options.register(AFFECTIVE_ANNOTATION, JSONL, AFFECTIVE_ANNOTATION_DIR / "example.jsonl")
+Options.register(AFFECTIVE_ANNOTATION, JSONArticle, AFFECTIVE_ANNOTATION_DIR / "article_example.json")

--- a/backend/data_export/pipeline/examples/affective_annotation/article_example.json
+++ b/backend/data_export/pipeline/examples/affective_annotation/article_example.json
@@ -11,7 +11,8 @@
                 "publish_datetime":"2022-08-01 13:59:59",
                 "crawled_datetime":"2022-09-05 08:12:45"
             },
-            "scale":[]
+            "scale":[],
+            "label":[]
             },
         {
             "id":5,
@@ -23,7 +24,8 @@
                 "publish_datetime":"2022-08-01 13:59:59",
                 "crawled_datetime":"2022-09-05 08:12:45"
             },
-            "scale":[]
+            "scale":[],
+            "label":[]
             },
         {
             "id":6,
@@ -35,7 +37,8 @@
                 "publish_datetime":"2022-08-01 13:59:59",
                 "crawled_datetime":"2022-09-05 08:12:45"
             },
-            "scale":[]
+            "scale":[],
+            "label":[]
             }
         ]
 }

--- a/backend/data_export/pipeline/examples/affective_annotation/article_example.json
+++ b/backend/data_export/pipeline/examples/affective_annotation/article_example.json
@@ -9,8 +9,9 @@
             "meta":{
                 "article_title":"10 Craziest Polish Tongue Twisters",
                 "publish_datetime":"2022-08-01 13:59:59",
-                "crawled_datetime":"2022-09-05 08:12:45"},
-                "scale":[]
+                "crawled_datetime":"2022-09-05 08:12:45"
+            },
+            "scale":[]
             },
         {
             "id":5,
@@ -20,8 +21,9 @@
             "meta":{
                 "article_title":"10 Craziest Polish Tongue Twisters",
                 "publish_datetime":"2022-08-01 13:59:59",
-                "crawled_datetime":"2022-09-05 08:12:45"},
-                "scale":[]
+                "crawled_datetime":"2022-09-05 08:12:45"
+            },
+            "scale":[]
             },
         {
             "id":6,
@@ -31,8 +33,9 @@
             "meta":{
                 "article_title":"10 Craziest Polish Tongue Twisters",
                 "publish_datetime":"2022-08-01 13:59:59",
-                "crawled_datetime":"2022-09-05 08:12:45"},
-                "scale":[]
+                "crawled_datetime":"2022-09-05 08:12:45"
+            },
+            "scale":[]
             }
         ]
 }

--- a/backend/data_export/pipeline/examples/affective_annotation/article_example.json
+++ b/backend/data_export/pipeline/examples/affective_annotation/article_example.json
@@ -1,0 +1,38 @@
+{
+    "article_id":"Eer9fFjy3gV7Y634t5rv6A\/3KhH4zL9NJtUgqZQMpvBXJ-8eabas8s5pveszg917vm1357",
+    "data":[
+        {
+            "id":4,
+            "text":"Stół z powyłamywanymi nogami",
+            "order":5,
+            "type":"subheader",
+            "meta":{
+                "article_title":"10 Craziest Polish Tongue Twisters",
+                "publish_datetime":"2022-08-01 13:59:59",
+                "crawled_datetime":"2022-09-05 08:12:45"},
+                "scale":[]
+            },
+        {
+            "id":5,
+            "text":"W Szczebrzeszynie chrząszcz brzmi w trzcinie.",
+            "order":10,
+            "type":"subheader",
+            "meta":{
+                "article_title":"10 Craziest Polish Tongue Twisters",
+                "publish_datetime":"2022-08-01 13:59:59",
+                "crawled_datetime":"2022-09-05 08:12:45"},
+                "scale":[]
+            },
+        {
+            "id":6,
+            "text":"Nowa generacja biosensora pozwoli na bieżąco analizować próbki potu",
+            "order":19,
+            "type":"subheader",
+            "meta":{
+                "article_title":"10 Craziest Polish Tongue Twisters",
+                "publish_datetime":"2022-08-01 13:59:59",
+                "crawled_datetime":"2022-09-05 08:12:45"},
+                "scale":[]
+            }
+        ]
+}

--- a/backend/data_export/pipeline/factories.py
+++ b/backend/data_export/pipeline/factories.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Type
 from django.db.models import QuerySet
 
 from . import writers
-from .catalog import CSV, JSON, JSONL, FastText
+from .catalog import CSV, JSON, JSONL, FastText, JSONArticle
 from .formatters import (
     DictFormatter,
     FastTextCategoryFormatter,
@@ -35,6 +35,7 @@ def create_writer(file_format: str) -> writers.Writer:
         JSON.name: writers.JsonWriter(),
         JSONL.name: writers.JsonlWriter(),
         FastText.name: writers.FastTextWriter(),
+        JSONArticle.name: writers.JsonArticleWriter(),
     }
     if file_format not in mapping:
         ValueError(f"Invalid format: {file_format}")
@@ -156,7 +157,22 @@ def create_formatter(project: Project, file_format: str) -> List[Formatter]:
                 TupledSpanFormatter(Scales.column),
                 TupledTextFormatter(TextQuestions.column),
                 RenameFormatter(**mapper_affective_annotation)
-            ],           
+            ],    
+            JSONArticle.name: [
+                TupledTextFormatter(TextQuestions.column),
+                RenameFormatter(**mapper_affective_annotation),
+            ]
+            if is_summary_mode
+            else [
+                TupledSpanFormatter(Scales.column),
+                RenameFormatter(**mapper_affective_annotation),
+            ]
+            if is_emotions_mode
+            else [
+                TupledSpanFormatter(Scales.column),
+                TupledTextFormatter(TextQuestions.column),
+                RenameFormatter(**mapper_affective_annotation)
+            ],
         },
     }
     return mapping[project.project_type][file_format]

--- a/backend/data_export/pipeline/writers.py
+++ b/backend/data_export/pipeline/writers.py
@@ -1,7 +1,7 @@
 import abc
 
 import pandas as pd
-
+import json
 
 class Writer(abc.ABC):
     extension = ""
@@ -42,3 +42,13 @@ class FastTextWriter(Writer):
     @staticmethod
     def write(file, dataset: pd.DataFrame):
         dataset.to_csv(file, index=False, encoding="utf-8", header=False)
+
+
+class JsonArticleWriter(Writer):
+    extension = "json"
+
+    @staticmethod
+    def write(file, dataset: pd.DataFrame):
+        dataset = dataset.groupby('article_id').apply(lambda x: x.drop('article_id',axis=1).to_json(orient='records')).reset_index(name='data')
+        dataset.data = dataset.data.apply(json.loads)
+        dataset.to_json(file, orient="records", force_ascii=False, lines=True)


### PR DESCRIPTION
What's changed:
- `backend/data_export/pipeline/writers.py`: added new writer - `JsonArticleWriter` to groupby the dataframe by `article_id` before writting its records to json file
- `backend/data_export/pipeline/factories.py`: added new mapping for exportation with the new writer
- `backend/data_export/pipeline/catalog.py`: registered new option for exportation in catalog
- `backend/data_export/pipeline/examples/affective_annotation/article_example.json`: added new example file for new type of data export

Screenshots:
New export option:
![image](https://user-images.githubusercontent.com/17596118/196153305-89cb74c1-f895-4222-8d62-091c1f501145.png)

Exported result from new option:
![Screenshot from 2022-10-17 12-14-52](https://user-images.githubusercontent.com/17596118/196152602-aec29b30-ff56-42b6-8f78-c318e2531eac.png)
