### PR TITLE
fix: Load "none" (-1) value properly when reopening Others annotation page

### DIFF
--- a/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
@@ -29,8 +29,8 @@
       </v-col>
       <v-col v-if="withCheckbox" cols="3" class="widget-row__checkbox">
         <v-checkbox
+          v-model="checkboxValue"
           :label="checkboxLabel"
-          @change="checkboxChangeHandler"
         />
       </v-col>
     </v-row>
@@ -82,7 +82,8 @@ export default {
       sliderMinVal: 0,
       sliderMaxVal: 10,
       isClicked: false,
-      enableSlider: true
+      enableSlider: true,
+      checkboxValue: false
     }
   },
 
@@ -94,19 +95,33 @@ export default {
       return 12
     },
     sliderThumbColor() {
-      if (this.mustClick) {
-        if (!this.isClicked && this.value === 0) {
-          return "transparent"
-        }
-        if (this.isClicked && this.enableSlider) {
-          return this.color
-        }
-        if (this.isClicked && !this.enableSlider) {
-          return "grey"
-        }
-        return this.color
+      if (this.mustClick && !this.isClicked && this.value < 0) {
+        return "transparent"
+      }
+      if (this.mustClick && this.isClicked && this.value < 0) {
+        return "transparent"
       }
       return this.color
+    }
+  },
+
+  watch: {
+    value() {
+      if (this.hideSliderOnChecked && this.value === -1) {
+        this.checkboxValue = true
+      }
+    },
+    checkboxValue(isChecked) {
+      if (this.hideSliderOnChecked && isChecked) {
+        console.log("core input - checkbox is true")
+        this.$emit('markCheckbox', this.categoryLabel)
+        this.enableSlider = false
+      }
+      if (this.hideSliderOnChecked && !isChecked) {
+        console.log("core input - checkbox is false")
+        this.$emit('unmarkCheckbox', this.categoryLabel)
+        this.enableSlider = true
+      }
     }
   },
 
@@ -117,16 +132,6 @@ export default {
     valueChangeHandler(newValue) {
       this.markClicked()
       this.$emit('change', newValue, this.categoryLabel)
-    },
-    checkboxChangeHandler(checkboxValue) {
-      if (this.hideSliderOnChecked && checkboxValue) {
-        this.$emit('markCheckbox', this.categoryLabel)
-        this.enableSlider = false
-      }
-      if (this.hideSliderOnChecked && !checkboxValue) {
-        this.$emit('unmarkCheckbox', this.categoryLabel)
-        this.enableSlider = true
-      }
     }
   }
 }

--- a/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
@@ -113,12 +113,10 @@ export default {
     },
     checkboxValue(isChecked) {
       if (this.hideSliderOnChecked && isChecked) {
-        console.log("core input - checkbox is true")
         this.$emit('markCheckbox', this.categoryLabel)
         this.enableSlider = false
       }
       if (this.hideSliderOnChecked && !isChecked) {
-        console.log("core input - checkbox is false")
         this.$emit('unmarkCheckbox', this.categoryLabel)
         this.enableSlider = true
       }

--- a/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
@@ -83,7 +83,8 @@ export default {
       sliderMaxVal: 10,
       isClicked: false,
       enableSlider: true,
-      checkboxValue: false
+      checkboxValue: false,
+      nullFlag: -1
     }
   },
 
@@ -107,7 +108,7 @@ export default {
 
   watch: {
     value() {
-      if (this.hideSliderOnChecked && this.value === -1) {
+      if (this.hideSliderOnChecked && this.value === this.nullFlag) {
         this.checkboxValue = true
       }
     },

--- a/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
@@ -138,12 +138,10 @@ export default {
     },
     checkboxValue(isChecked) {
       if (this.hideTextfieldOnChecked && isChecked) {
-        console.log("core input - checkbox is true")
         this.$emit('markCheckbox', this.categoryLabel)
         this.enableTextfield = false
       }
       if (this.hideTextfieldOnChecked && !isChecked) {
-        console.log("core input - checkbox is false")
         this.$emit('unmarkCheckbox', this.categoryLabel)
         this.enableTextfield = true
       }
@@ -233,13 +231,5 @@ export default {
     &__warning {
       color: red;
     }
-  }
-
-  .textfield-data-normal {
-    color: black !important;
-  }
-
-  .textfield-data-hidden {
-    color: red !important;
   }
 </style>

--- a/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
@@ -17,7 +17,7 @@
           small
           dense
           readonly
-          :value="stringifiedAnswers === '-1' ? '' : stringifiedAnswers"
+          :value="stringifiedAnswers === nullFlag ? '' : stringifiedAnswers"
           :rules="rulesTextfield"
           hide-details="auto"
         />
@@ -108,7 +108,8 @@ export default {
       enableTextfield: true,
       showDialog: false,
       dialogErrorMessage: "",
-      stringifiedAnswers: ""
+      stringifiedAnswers: "",
+      nullFlag: "-1"
     }
   },
 
@@ -132,7 +133,7 @@ export default {
       const res = this.answers.map((value) => value.text)
       this.stringifiedAnswers = res.join(", ")
 
-      if (this.hideTextfieldOnChecked && this.stringifiedAnswers === "-1") {
+      if (this.hideTextfieldOnChecked && this.stringifiedAnswers === this.nullFlag) {
         this.checkboxValue = true
       }
     },

--- a/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
@@ -17,7 +17,7 @@
           small
           dense
           readonly
-          :value="stringifiedAnswers"
+          :value="stringifiedAnswers === '-1' ? '' : stringifiedAnswers"
           :rules="rulesTextfield"
           hide-details="auto"
         />

--- a/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
@@ -24,8 +24,8 @@
       </v-col>
       <v-col v-if="withCheckbox" cols="3" class="widget__checkbox">
         <v-checkbox
+          v-model="checkboxValue"
           :label="checkboxLabel"
-          @change="checkboxChangeHandler"
         />
       </v-col>
     </v-row>
@@ -104,6 +104,7 @@ export default {
 
   data() {
     return {
+      checkboxValue: false,
       enableTextfield: true,
       showDialog: false,
       dialogErrorMessage: "",
@@ -130,6 +131,22 @@ export default {
     answers() {
       const res = this.answers.map((value) => value.text)
       this.stringifiedAnswers = res.join(", ")
+
+      if (this.hideTextfieldOnChecked && this.stringifiedAnswers === "-1") {
+        this.checkboxValue = true
+      }
+    },
+    checkboxValue(isChecked) {
+      if (this.hideTextfieldOnChecked && isChecked) {
+        console.log("core input - checkbox is true")
+        this.$emit('markCheckbox', this.categoryLabel)
+        this.enableTextfield = false
+      }
+      if (this.hideTextfieldOnChecked && !isChecked) {
+        console.log("core input - checkbox is false")
+        this.$emit('unmarkCheckbox', this.categoryLabel)
+        this.enableTextfield = true
+      }
     }
   },
 
@@ -158,16 +175,6 @@ export default {
         this.$emit('add', text)
       } else {
         this.dialogErrorMessage = errorMessage
-      }
-    },
-    checkboxChangeHandler(checkboxValue) {
-      if (this.hideTextfieldOnChecked && checkboxValue) {
-        this.$emit('markCheckbox', this.categoryLabel)
-        this.enableTextfield = false
-      }
-      if (this.hideTextfieldOnChecked && !checkboxValue) {
-        this.$emit('unmarkCheckbox', this.categoryLabel)
-        this.enableTextfield = true
       }
     },
     textfieldClickHandler() {
@@ -227,4 +234,12 @@ export default {
       color: red;
     }
   }
-  </style>
+
+  .textfield-data-normal {
+    color: black !important;
+  }
+
+  .textfield-data-hidden {
+    color: red !important;
+  }
+</style>

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -469,6 +469,7 @@ export default {
       this.affectiveOthersWishToAuthor = affectiveTextlabels.filter(
         (item) => item.question === this.affectiveTextlabelQuestions.othersWishToAuthor
       )
+      console.log(this.affectiveOthersWishToAuthor)
 
       const affectiveScalesValues = {}
       const affectiveScalesDict = this.affectiveScalesDict
@@ -662,6 +663,7 @@ export default {
       await this.list(this.doc.id)
     },
     async updateWishToAuthor(annotationId, text) {
+      console.log("index - update wish to author")
       await this.$services.affectiveTextlabel.changeText(this.projectId, this.doc.id, annotationId, text)
       await this.list(this.doc.id)
     },
@@ -678,15 +680,23 @@ export default {
       this.affectiveOthersTmp.wishToAuthor = this.affectiveOthersWishToAuthor
       if (this.affectiveOthersWishToAuthor.length > 0) {
         const annotationId = this.affectiveOthersWishToAuthor[0].id
-        await this.removeWishToAuthor(annotationId)
-        await this.list(this.doc.id)
+        const currentText = this.affectiveOthersWishToAuthor[0].text
+        if (currentText !== "-1") {
+          await this.removeWishToAuthor(annotationId)
+          await this.addWishToAuthor("-1")
+        }
       }
     },
     async restoreWishToAuthor() {
       if (this.affectiveOthersTmp.wishToAuthor.length > 0) {
+        if (this.affectiveOthersWishToAuthor.length > 0) {
+          const annotationId = this.affectiveOthersWishToAuthor[0].id
+          await this.removeWishToAuthor(annotationId)
+        }
         const text = this.affectiveOthersTmp.wishToAuthor[0].text
-        await this.addWishToAuthor(text)
-        await this.list(this.doc.id)
+        if (text !== "-1") {
+          await this.addWishToAuthor(text)
+        }
       }
     },
     async updateScale(labelId, value) {

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -469,7 +469,6 @@ export default {
       this.affectiveOthersWishToAuthor = affectiveTextlabels.filter(
         (item) => item.question === this.affectiveTextlabelQuestions.othersWishToAuthor
       )
-      console.log(this.affectiveOthersWishToAuthor)
 
       const affectiveScalesValues = {}
       const affectiveScalesDict = this.affectiveScalesDict
@@ -652,13 +651,11 @@ export default {
     },
     async nullifyOthersValueHandler(category) {
       if (this.affectiveScalesValues[category] !== -1) {
-        console.log("index - nullify category")
         this.affectiveOthersTmp[category] = this.affectiveScalesValues[category]
         await this.othersChangeHandler(-1, category)
       }
     },
     async restoreOthersValueHandler(category) {
-      console.log("index - restore category")
       const previousValue = this.affectiveOthersTmp[category] || 0
       await this.othersChangeHandler(previousValue, category)
     },
@@ -667,7 +664,6 @@ export default {
       await this.list(this.doc.id)
     },
     async updateWishToAuthor(annotationId, text) {
-      console.log("index - update wish to author")
       await this.$services.affectiveTextlabel.changeText(this.projectId, this.doc.id, annotationId, text)
       await this.list(this.doc.id)
     },

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -651,10 +651,14 @@ export default {
       await this.list(this.doc.id)
     },
     async nullifyOthersValueHandler(category) {
-      this.affectiveOthersTmp[category] = this.affectiveScalesValues[category]
-      await this.othersChangeHandler(-1, category)
+      if (this.affectiveScalesValues[category] !== -1) {
+        console.log("index - nullify category")
+        this.affectiveOthersTmp[category] = this.affectiveScalesValues[category]
+        await this.othersChangeHandler(-1, category)
+      }
     },
     async restoreOthersValueHandler(category) {
+      console.log("index - restore category")
       const previousValue = this.affectiveOthersTmp[category] || 0
       await this.othersChangeHandler(previousValue, category)
     },

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -685,17 +685,19 @@ export default {
           await this.removeWishToAuthor(annotationId)
           await this.addWishToAuthor("-1")
         }
+      } else {
+        await this.addWishToAuthor("-1")
       }
     },
     async restoreWishToAuthor() {
-      if (this.affectiveOthersTmp.wishToAuthor.length > 0) {
-        if (this.affectiveOthersWishToAuthor.length > 0) {
-          const annotationId = this.affectiveOthersWishToAuthor[0].id
-          await this.removeWishToAuthor(annotationId)
-        }
-        const text = this.affectiveOthersTmp.wishToAuthor[0].text
-        if (text !== "-1") {
-          await this.addWishToAuthor(text)
+      if (this.affectiveOthersWishToAuthor.length > 0) {
+        const annotationId = this.affectiveOthersWishToAuthor[0].id
+        await this.removeWishToAuthor(annotationId)
+        if (this.affectiveOthersTmp.wishToAuthor.length > 0) {
+          const text = this.affectiveOthersTmp.wishToAuthor[0].text
+          if (text !== "-1") {
+            await this.addWishToAuthor(text)
+          }
         }
       }
     },

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -289,6 +289,8 @@ export default {
         othersWishToAuthor: "Czego życzę autorowi tego tekstu?"
       },
       affectiveScalesDict: {},
+      intNullFlag: -1,
+      strNullFlag: "-1",
       affectiveSummaryTags: [],
       affectiveSummaryImpressions: [],
       affectiveOthersWishToAuthor: [],
@@ -650,9 +652,9 @@ export default {
       await this.list(this.doc.id)
     },
     async nullifyOthersValueHandler(category) {
-      if (this.affectiveScalesValues[category] !== -1) {
+      if (this.affectiveScalesValues[category] !== this.intNullFlag) {
         this.affectiveOthersTmp[category] = this.affectiveScalesValues[category]
-        await this.othersChangeHandler(-1, category)
+        await this.othersChangeHandler(this.intNullFlag, category)
       }
     },
     async restoreOthersValueHandler(category) {
@@ -681,12 +683,12 @@ export default {
       if (this.affectiveOthersWishToAuthor.length > 0) {
         const annotationId = this.affectiveOthersWishToAuthor[0].id
         const currentText = this.affectiveOthersWishToAuthor[0].text
-        if (currentText !== "-1") {
+        if (currentText !== this.strNullFlag) {
           await this.removeWishToAuthor(annotationId)
-          await this.addWishToAuthor("-1")
+          await this.addWishToAuthor(this.strNullFlag)
         }
       } else {
-        await this.addWishToAuthor("-1")
+        await this.addWishToAuthor(this.strNullFlag)
       }
     },
     async restoreWishToAuthor() {
@@ -695,7 +697,7 @@ export default {
         await this.removeWishToAuthor(annotationId)
         if (this.affectiveOthersTmp.wishToAuthor.length > 0) {
           const text = this.affectiveOthersTmp.wishToAuthor[0].text
-          if (text !== "-1") {
+          if (text !== this.strNullFlag) {
             await this.addWishToAuthor(text)
           }
         }


### PR DESCRIPTION
This PR solves the issue in affective annotation Others mode when marking a "nie wiem" checkbox (in which case, the value is saved as -1 in db), and then user closes the project and reopen it, the checkbox won't be marked. The issue happens with both slider and textlabel inputs in Others mode. However, the issue does not affect the other modes, because only the Others mode contain "nie wiem" checkboxes that are treated as -1 value.

With this fix, "nie wiem" checkboxes should be reloaded correctly for both slider and textlabel inputs.

Notable:
- Because the question "Czego życzę autorowi tego tekstu?" is open question but it can be marked as "none" (-1), there is this "quirk" : when user marks the field as "nie mam życzeń", and then closes the annotation page, and then reopens it, now the checkbox is marked, the textfield is disabled, but the string "-1" is visible inside the textfield. But I think this is rather minor. 😓 I tried to make the text inside the textfield white/transparent when the value is "-1" but I couldn't make it work....

What's changed:
 - frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue : Added v-model to change the checkbox value dynamically
 - frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue : Added v-model to change the checkbox value dynamically
 - frontend/pages/projects/_id/affective-annotation/index.vue : Adjustment in the code that handles marking and unmarking checkbox
 
Screenshots:
<img width="960" alt="ss" src="https://user-images.githubusercontent.com/64476430/197612629-32810f5a-7bc8-4350-b822-de9aa52f34ba.PNG">
<img width="960" alt="sss" src="https://user-images.githubusercontent.com/64476430/197614873-4250a712-c26b-4bb9-ac6a-624c46b21629.PNG">

