### PR TITLE
feat: Scale labels auto-import, annotation break after finishing a project

### DIFF
--- a/frontend/components/utils/RestingPeriodModal.vue
+++ b/frontend/components/utils/RestingPeriodModal.vue
@@ -1,0 +1,37 @@
+<template>
+  <v-dialog
+    v-model="dialog"
+    fullscreen
+    persistent
+  >
+    <v-card>
+      <v-card-title>
+        <p>Time to rest!</p>
+      </v-card-title>
+      <v-card-text>
+        <p>Thank you for your work! Please have some coffee before continuing!</p>
+        <p>You can continue annotating at: {{ endTime }}</p>
+        <p>Please refresh this page when the time to rest has ended.</p>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  props: {
+    endTime: {
+      type: Date,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      dialog: true
+    }
+  }
+})
+</script>

--- a/frontend/components/utils/RestingPeriodModal.vue
+++ b/frontend/components/utils/RestingPeriodModal.vue
@@ -6,18 +6,27 @@
   >
     <v-card>
       <v-card-title>
-        <p>Time to rest!</p>
+        <p>{{ $t('generic.restingMessage.title') }}</p>
       </v-card-title>
       <v-card-text>
-        <p>Thank you for your work! Please have some coffee before continuing!</p>
-        <p>You can continue annotating at: {{ endTime }}</p>
-        <p>Please refresh this page when the time to rest has ended.</p>
+        <p>{{ $t('generic.restingMessage.message1') }}</p>
+        <p>{{ $t('generic.restingMessage.message2') }} {{ endTime }}</p>
+        <p>{{ $t('generic.restingMessage.message3') }}</p>
+
+        <v-row justify="end">
+          <button class="mr-5" @click="signout">
+            <v-icon class="button-logout-icon" :style="{ display: 'inline' }">{{ mdiLogout }}</v-icon>
+            <div class="button-logout-text" :style="{ display: 'inline' }">{{ $t('user.signOut') }}</div>
+          </button>
+        </v-row>
       </v-card-text>
     </v-card>
   </v-dialog>
 </template>
 
 <script lang="ts">
+import { mdiLogout } from '@mdi/js'
+import { mapActions } from 'vuex'
 import Vue from 'vue'
 
 export default Vue.extend({
@@ -30,8 +39,28 @@ export default Vue.extend({
 
   data() {
     return {
+      mdiLogout,
       dialog: true
+    }
+  },
+
+  methods: {
+    ...mapActions('auth', ['logout']),
+    signout() {
+      this.logout()
+      this.$router.push(this.localePath('/'))
     }
   }
 })
 </script>
+
+<style>
+.button-logout-icon {
+  display: 'inline';
+}
+
+.button-logout-text:hover {
+  text-decoration: underline;
+  display: 'inline';
+}
+</style>

--- a/frontend/i18n/de/generic.js
+++ b/frontend/i18n/de/generic.js
@@ -16,5 +16,11 @@ export default {
   export: 'Exportieren',
   description: 'Beschreibung',
   type: 'Typ',
-  loading: 'Laden... bitte warten'
+  loading: 'Laden... bitte warten',
+  restingMessage: {
+    title: 'Zeit zum ausruhen!',
+    message1: 'Danke für deine Arbeit! Bitte trinken Sie einen Kaffee, bevor Sie fortfahren!',
+    message2: 'Sie können mit dem Kommentieren fortfahren:',
+    message3: 'Bitte aktualisieren Sie diese Seite, wenn die Ruhezeit abgelaufen ist.'
+  }
 }

--- a/frontend/i18n/en/generic.js
+++ b/frontend/i18n/en/generic.js
@@ -17,5 +17,11 @@ export default {
   export: 'Export',
   description: 'Description',
   type: 'Type',
-  loading: 'Loading... Please wait'
+  loading: 'Loading... Please wait',
+  restingMessage: {
+    title: 'Time to rest!',
+    message1: 'Thank you for your work! Please have some coffee before continuing!',
+    message2: 'You can continue annotating at:',
+    message3: 'Please refresh this page when the time to rest has ended.'
+  }
 }

--- a/frontend/i18n/fr/generic.js
+++ b/frontend/i18n/fr/generic.js
@@ -16,5 +16,11 @@ export default {
   export: 'Exporter',
   description: 'Description',
   type: 'Type',
-  loading: 'Chargement... veuillez patienter'
+  loading: 'Chargement... veuillez patienter',
+  restingMessage: {
+    title: 'Temps de repos!',
+    message1: 'Merci pour votre travail! Prenez un café avant de continuer !',
+    message2: 'Vous pouvez continuer à annoter à :',
+    message3: 'Veuillez actualiser cette page lorsque le temps de repos est terminé.'
+  }
 }

--- a/frontend/i18n/pl/generic.js
+++ b/frontend/i18n/pl/generic.js
@@ -17,5 +17,11 @@ export default {
   export: 'Eksport',
   description: 'Opis',
   type: 'Typ',
-  loading: 'Wczytywanie... Proszę czekać'
+  loading: 'Wczytywanie... Proszę czekać',
+  restingMessage: {
+    title: 'Czas na odpoczynek!',
+    message1: 'Dziękujemy za Twoją pracę! Proszę napić się kawy, zanim przejdziesz dalej!',
+    message2: 'Możesz kontynuować anotację od:',
+    message3: 'Odśwież tę stronę, gdy czas na odpoczynek się skończy.'
+  }
 }

--- a/frontend/i18n/zh/generic.js
+++ b/frontend/i18n/zh/generic.js
@@ -16,5 +16,11 @@ export default {
   export: '导出',
   description: '描述',
   type: '类型',
-  loading: '加载中... 请等待'
+  loading: '加载中... 请等待',
+  restingMessage: {
+    title: '休息时间!',
+    message1: '感谢您的工作! 请先喝杯咖啡再继续!',
+    message2: '您可以在此日期继续注释:',
+    message3: '请在休息时间结束后刷新此页面.'
+  }
 }

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -46,7 +46,8 @@ export default {
     '~/plugins/vue-shortkey.js',
     '~/plugins/services.ts',
     '~/plugins/color.ts',
-    '~/plugins/role.ts'
+    '~/plugins/role.ts',
+    '~/plugins/persistedState.client.js'
   ],
   /*
    ** Nuxt.js modules

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     "vue-template-compiler": "^2.6.14",
     "vue-youtube": "^1.4.0",
     "vuetify": "^2.*",
+    "vuex-persistedstate": "^4.1.0",
     "wavesurfer.js": "^5.1.0",
     "webpack": "^4.46.0",
     "yarn": "^1.22.10"

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -203,8 +203,8 @@
         </v-card-text>
       </v-card>
       <list-metadata :metadata="doc.meta" class="mt-4" />
+      <resting-period-modal v-if="showRestingMessage" :end-time="restingEndTime" />
     </template>
-    <resting-period-modal v-if="showRestingMessage" :end-time="restingEndTime" />
   </layout-text>
 </template>
 
@@ -372,19 +372,7 @@ export default {
   },
 
   async created() {
-    let hasRested = false
-    const currentTime = new Date()
-    const restingEndTime = this.getRestingEndTime()
-
-    if (restingEndTime === null || currentTime >= restingEndTime) {
-      hasRested = true
-      this.showRestingMessage = false
-      this.restingEndTime = currentTime
-    } else {
-      hasRested = false
-      this.showRestingMessage = true
-      this.restingEndTime = restingEndTime
-    }
+    const hasRested = this.checkRestingPeriod()
 
     if (hasRested) {
       this.clearRestingPeriod()
@@ -430,6 +418,22 @@ export default {
     ...mapGetters('auth', ['getRestingEndTime']),
     ...mapActions('auth', ['setRestingPeriod', 'clearRestingPeriod']),
 
+    checkRestingPeriod() {
+      const currentTime = new Date()
+      const restingEndTime = this.getRestingEndTime()
+
+      if (restingEndTime === null || currentTime >= restingEndTime) {
+        this.showRestingMessage = false
+        this.restingEndTime = currentTime
+
+        return true
+      } else {
+        this.showRestingMessage = true
+        this.restingEndTime = restingEndTime
+
+        return false
+      }
+    },
     async setDoc() {
       const query = this.$route.query.q || ''
       const isChecked = this.$route.query.isChecked || ''

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -375,7 +375,6 @@ export default {
     let hasRested = false
     const currentTime = new Date()
     const restingEndTime = this.getRestingEndTime()
-    console.log(restingEndTime)
 
     if (restingEndTime === null || currentTime >= restingEndTime) {
       hasRested = true

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -80,15 +80,12 @@ export default Vue.extend({
   created() {
     const currentTime = new Date()
     const restingEndTime = this.getRestingEndTime()
-    console.log(restingEndTime)
 
     if (restingEndTime === null || currentTime >= restingEndTime) {
-      console.log("work!")
       this.showRestingMessage = false
       this.restingEndTime = currentTime
       this.clearRestingPeriod()
     } else {
-      console.log("rest time!")
       this.showRestingMessage = true
       this.restingEndTime = restingEndTime
     }

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -78,22 +78,25 @@ export default Vue.extend({
   },
 
   created() {
-    const currentTime = new Date()
-    const restingEndTime = this.getRestingEndTime()
-
-    if (restingEndTime === null || currentTime >= restingEndTime) {
-      this.showRestingMessage = false
-      this.restingEndTime = currentTime
-      this.clearRestingPeriod()
-    } else {
-      this.showRestingMessage = true
-      this.restingEndTime = restingEndTime
-    }
+    this.checkRestingPeriod()
   },
 
   methods: {
     ...mapGetters('auth', ['getRestingEndTime']),
     ...mapActions('auth', ['setRestingPeriod', 'clearRestingPeriod']),
+
+    checkRestingPeriod() {
+      const currentTime = new Date()
+      const restingEndTime = this.getRestingEndTime()
+      if (restingEndTime === null || currentTime >= restingEndTime) {
+        this.showRestingMessage = false
+        this.restingEndTime = currentTime
+        this.clearRestingPeriod()
+      } else {
+        this.showRestingMessage = true
+        this.restingEndTime = restingEndTime
+      }
+    },
 
     async remove() {
       await this.$services.project.bulkDelete(this.selected)

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -23,21 +23,24 @@
       :total="projects.count"
       @update:query="updateQuery"
     />
+    <resting-period-modal v-if="showRestingMessage" :end-time="restingEndTime" />
   </v-card>
 </template>
 
 <script lang="ts">
 import _ from 'lodash'
 import Vue from 'vue'
-import { mapGetters } from 'vuex'
+import { mapGetters, mapActions } from 'vuex'
 import ProjectList from '@/components/project/ProjectList.vue'
+import RestingPeriodModal from '@/components/utils/RestingPeriodModal.vue'
 import { ProjectDTO, ProjectListDTO } from '~/services/application/project/projectData'
 import FormDelete from '~/components/project/FormDelete.vue'
 
 export default Vue.extend({
   components: {
     FormDelete,
-    ProjectList
+    ProjectList,
+    RestingPeriodModal
   },
   layout: 'projects',
 
@@ -48,7 +51,9 @@ export default Vue.extend({
       dialogDelete: false,
       projects: {} as ProjectListDTO,
       selected: [] as ProjectDTO[],
-      isLoading: false
+      isLoading: false,
+      showRestingMessage: false,
+      restingEndTime: new Date()
     }
   },
 
@@ -72,7 +77,27 @@ export default Vue.extend({
     }, 1000)
   },
 
+  created() {
+    const currentTime = new Date()
+    const restingEndTime = this.getRestingEndTime()
+    console.log(restingEndTime)
+
+    if (restingEndTime === null || currentTime >= restingEndTime) {
+      console.log("work!")
+      this.showRestingMessage = false
+      this.restingEndTime = currentTime
+      this.clearRestingPeriod()
+    } else {
+      console.log("rest time!")
+      this.showRestingMessage = true
+      this.restingEndTime = restingEndTime
+    }
+  },
+
   methods: {
+    ...mapGetters('auth', ['getRestingEndTime']),
+    ...mapActions('auth', ['setRestingPeriod', 'clearRestingPeriod']),
+
     async remove() {
       await this.$services.project.bulkDelete(this.selected)
       this.$fetch()

--- a/frontend/plugins/persistedState.client.js
+++ b/frontend/plugins/persistedState.client.js
@@ -1,0 +1,5 @@
+import createPersistedState from 'vuex-persistedstate'
+
+export default ({ store }) => {
+  createPersistedState()(store)
+}

--- a/frontend/store/auth.js
+++ b/frontend/store/auth.js
@@ -47,7 +47,6 @@ export const getters = {
     return state.isStaff
   },
   getRestingEndTime(state) {
-    console.log(state.restingEndTime)
     if (state.restingEndTime !== null) {
       return moment(state.restingEndTime, 'ddd, DD-MM-YYYY HH:mm:ss').toDate()
     }
@@ -62,7 +61,6 @@ export const actions = {
     commit('setRestingPeriod', endTime)
   },
   clearRestingPeriod({ commit }) {
-    console.log("clearRestingPeriod")
     commit('clearRestingPeriod')
   },
   async authenticateUser({ commit }, authData) {

--- a/frontend/store/auth.js
+++ b/frontend/store/auth.js
@@ -1,8 +1,11 @@
+import moment from 'moment'
+
 export const state = () => ({
   username: null,
   id: null,
   isAuthenticated: false,
-  isStaff: false
+  isStaff: false,
+  restingEndTime: null
 })
 
 export const mutations = {
@@ -20,6 +23,13 @@ export const mutations = {
   },
   setIsStaff(state, isStaff) {
     state.isStaff = isStaff
+  },
+  setRestingPeriod(state, endTime) {
+    const restingEndTime = moment(endTime).format('ddd, DD-MM-YYYY HH:mm:ss')
+    state.restingEndTime = restingEndTime
+  },
+  clearRestingPeriod(state) {
+    state.restingEndTime = null
   }
 }
 
@@ -35,10 +45,26 @@ export const getters = {
   },
   isStaff(state) {
     return state.isStaff
+  },
+  getRestingEndTime(state) {
+    console.log(state.restingEndTime)
+    if (state.restingEndTime !== null) {
+      return moment(state.restingEndTime, 'ddd, DD-MM-YYYY HH:mm:ss').toDate()
+    }
+    return null
   }
 }
 
 export const actions = {
+  setRestingPeriod({ commit }) {
+    const startTime = new Date()
+    const endTime = moment(startTime).add(5, 'm').toDate()
+    commit('setRestingPeriod', endTime)
+  },
+  clearRestingPeriod({ commit }) {
+    console.log("clearRestingPeriod")
+    commit('clearRestingPeriod')
+  },
   async authenticateUser({ commit }, authData) {
     try {
       await this.$services.auth.login(authData.username, authData.password)

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10225,7 +10225,7 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   version "2.2.0-c"
   resolved "https://github.com/nhn/raphael.git#78a6ed3ec269f33b6457b0ec66f8c3d1f2ed70e0"
   dependencies:
-    eve "https://github.com/adobe-webplatform/eve.git#eef80ed"
+    eve "git://github.com/adobe-webplatform/eve.git#eef80ed"
 
 raw-loader@^4.0.2:
   version "4.0.2"
@@ -10886,6 +10886,11 @@ shell-quote@^1.6.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
+
+shvl@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.3.tgz#eb4bd37644f5684bba1fc52c3010c96fb5e6afd1"
+  integrity sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -12288,6 +12293,14 @@ vuetify@^2.6:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.6.2.tgz#1ed4d3c9e734d55202bd566b789cce0e0013279a"
   integrity sha512-nx3uZkO8MZNMshUEh1xKaQ1hQYepNwWFn3FVxKt+XBVf7ZFscd0GS/a3KZo4B3baXQmziCQAZKNIQF5IWeaIUw==
+
+vuex-persistedstate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-4.1.0.tgz#127165f85f5b4534fb3170a5d3a8be9811bd2a53"
+  integrity sha512-3SkEj4NqwM69ikJdFVw6gObeB0NHyspRYMYkR/EbhR0hbvAKyR5gksVhtAfY1UYuWUOCCA0QNGwv9pOwdj+XUQ==
+  dependencies:
+    deepmerge "^4.2.2"
+    shvl "^2.0.3"
 
 vuex@^3.6.2:
   version "3.6.2"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10225,7 +10225,7 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   version "2.2.0-c"
   resolved "https://github.com/nhn/raphael.git#78a6ed3ec269f33b6457b0ec66f8c3d1f2ed70e0"
   dependencies:
-    eve "git://github.com/adobe-webplatform/eve.git#eef80ed"
+    eve "https://github.com/adobe-webplatform/eve.git#eef80ed"
 
 raw-loader@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
This PR aims to solve 2 things: (1) adding an automatic import of scale labels for affective annotation project, (2) creating an annotation break mechanism after finishing a project.

The annotation break is implemented inside the annotatin page, in method `async updateProgress()`. This method is normally used for updating the annotation progress bar. The progress bar increases each time a text has been marked as done / confirmed, until eventually it reaches 100%. I added some code to check if there is no more text to annotate, and if yes then set the `restingEndTime` (calculated as current datetime plus **5 minutes**) and redirect to project list page, on which a message will be shown.

Notably, the resting period is currently hard-coded as 5 minutes from the moment the user marked the last text as done. Later we can add an option to variably set how many minutes to rest, but for now I think 5 minutes is ok.

# Scale labels auto-import
What's changed:
 - frontend/pages/projects/create.vue : Add the automatic import of scale labels file based on the mode after project creation

# Annotation break after finishing a project
What's changed:
 - frontend/package.json : Added `vuex-persistedstate` dependency, which is needed to prevent losing stored data upon refresh.
 - frontend/yarn.lock : Changed due to adding `vuex-persistedstate`.
 - frontend/nuxt.config.js : Registered the new plugin `persistedState.client.js`.
 - frontend/store/auth.js : Added `restingEndTime` to the state, which is for storing the end time of the resting period as a datetime string.
 - frontend/pages/projects/index.vue : Added a check if current time is greater than `restingEndTime`. If not, then show `RestingPeriodModal`.
 - frontend/pages/projects/_id/affective-annotation/index.vue : Modified method `async updateProgress()`, it now checks if all texts have been confirmed, and if yes then it will set the resting period and redirect the user to the project list page. Also, added a similar mechanism of checking `restingEndTime` in `async created()` to prevent user jumping straight into the annotation page by typing the url.
 - frontend/i18n/* : Add translations for the message in the resting modal

What's new:
 - frontend/plugins/persistedState.client.js : A plugin for making all data in vuex store persistent.
 - frontend/components/utils/RestingPeriodModal.vue : A modal that is shown full-screen when user should be in resting period.
