### PR TITLE
fix: Make resting message modal stick to one account only, adjust checkbox behavior in Others mode

### DIFF
--- a/frontend/components/project/FormCreate.vue
+++ b/frontend/components/project/FormCreate.vue
@@ -118,6 +118,7 @@
             />
           </v-col>
           <v-col v-if="isAffectiveAnnotationProject" col="5">
+            <p class="font-weight-bold mb-0">Mode</p>
             <v-radio-group 
               @change="updateValue('affectiveProjectMode', $event)"
             >
@@ -128,7 +129,8 @@
                 :value="affectiveAnnotationOption.value"
               ></v-radio>
             </v-radio-group>
-             <v-radio-group 
+            <p class="font-weight-bold mb-0">View</p>
+            <v-radio-group
               @change="updateValue('isSingleAnnView', $event)"
             >
               <v-radio

--- a/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
@@ -114,11 +114,7 @@ export default {
 
   watch: {
     value() {
-      if (this.hideSliderOnChecked && this.value === this.nullFlag) {
-        this.checkboxValue = true
-      } else {
-        this.checkboxValue = false
-      }
+      this.checkboxValue = this.hideSliderOnChecked && this.value === this.nullFlag
     },
     checkboxValue(isChecked) {
       if (this.hideSliderOnChecked && isChecked) {

--- a/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
@@ -116,6 +116,8 @@ export default {
     value() {
       if (this.hideSliderOnChecked && this.value === this.nullFlag) {
         this.checkboxValue = true
+      } else {
+        this.checkboxValue = false
       }
     },
     checkboxValue(isChecked) {

--- a/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
@@ -138,11 +138,7 @@ export default {
       const res = this.answers.map((value) => value.text)
       this.stringifiedAnswers = res.join(", ")
 
-      if (this.hideTextfieldOnChecked && this.stringifiedAnswers === this.nullFlag) {
-        this.checkboxValue = true
-      } else {
-        this.checkboxValue = false
-      }
+      this.checkboxValue = this.hideTextfieldOnChecked && this.stringifiedAnswers === this.nullFlag
     },
     checkboxValue(isChecked) {
       if (this.hideTextfieldOnChecked && isChecked) {

--- a/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
@@ -140,6 +140,8 @@ export default {
 
       if (this.hideTextfieldOnChecked && this.stringifiedAnswers === this.nullFlag) {
         this.checkboxValue = true
+      } else {
+        this.checkboxValue = false
       }
     },
     checkboxValue(isChecked) {

--- a/frontend/components/tasks/toolbar/buttons/ButtonClear.vue
+++ b/frontend/components/tasks/toolbar/buttons/ButtonClear.vue
@@ -1,7 +1,7 @@
 <template>
   <v-tooltip bottom>
     <template #activator="{ on }">
-      <v-btn icon v-on="on" :disabled="disabled" @click="$emit('click:clear')">
+      <v-btn icon :disabled="disabled" v-on="on" @click="$emit('click:clear')">
         <v-icon>
           {{ mdiDeleteOutline }}
         </v-icon>

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -843,8 +843,7 @@ export default {
         const annotationId = this.affectiveOthersWishToAuthor[0].id
         const currentText = this.affectiveOthersWishToAuthor[0].text
         if (currentText !== this.strNullFlag) {
-          await this.removeWishToAuthor(annotationId)
-          await this.addWishToAuthor(this.strNullFlag)
+          await this.updateWishToAuthor(annotationId, this.strNullFlag)
         }
       } else {
         await this.addWishToAuthor(this.strNullFlag)

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -470,7 +470,6 @@ export default {
   async created() {
     const hasRested = this.checkRestingPeriod()
     if (hasRested) {
-      await this.clearRestingPeriod()
       await this.setLabelData()
       this.setAffectiveProjectScaleDataDict()
       this.setAffectiveProjectScaleData()
@@ -483,22 +482,16 @@ export default {
   },
 
   methods: {
-    ...mapGetters('auth', ['getRestingEndTime']),
-    ...mapActions('auth', ['setRestingPeriod', 'clearRestingPeriod']),
+    ...mapActions('auth', ['setRestingPeriod', 'getRestingPeriod']),
 
-    checkRestingPeriod() {
-      const currentTime = new Date()
-      const restingEndTime = this.getRestingEndTime()
-
-      if (restingEndTime === null || currentTime >= restingEndTime) {
+    async checkRestingPeriod() {
+      const restingEndTime = await this.getRestingPeriod()
+      if (restingEndTime === null) {
         this.showRestingMessage = false
-        this.restingEndTime = currentTime
-
         return true
       } else {
         this.showRestingMessage = !this.isProjectAdmin
         this.restingEndTime = restingEndTime
-
         return false
       }
     },

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -82,16 +82,12 @@ export default Vue.extend({
   },
 
   methods: {
-    ...mapGetters('auth', ['getRestingEndTime', 'getUserId']),
-    ...mapActions('auth', ['setRestingPeriod', 'clearRestingPeriod']),
+    ...mapActions('auth', ['setRestingPeriod', 'getRestingPeriod']),
 
-    checkRestingPeriod() {
-      const currentTime = new Date()
-      const restingEndTime = this.getRestingEndTime()
-      if (restingEndTime === null || currentTime >= restingEndTime) {
+    async checkRestingPeriod() {
+      const restingEndTime = await this.getRestingPeriod()
+      if (restingEndTime === null) {
         this.showRestingMessage = false
-        this.restingEndTime = currentTime
-        this.clearRestingPeriod()
       } else {
         this.showRestingMessage = !this.isStaff
         this.restingEndTime = restingEndTime

--- a/frontend/store/auth.js
+++ b/frontend/store/auth.js
@@ -64,14 +64,18 @@ export const actions = {
   },
   getRestingPeriod({ commit, getters }) {
     const currentTime = new Date()
-    const restingEndTime = getters('getRestingEndTime')
+    const restingEndTime = getters.getRestingEndTime
 
     if (currentTime >= restingEndTime) {
       commit('clearRestingPeriod')
     }
 
-    const currentUserId = getters('getUserId')
-    const restingUserId = getters('getRestingUserId')
+    const currentUserId = getters.getUserId
+    const restingUserId = getters.getRestingUserId
+
+    console.log(restingEndTime)
+    console.log(currentUserId)
+    console.log(restingUserId)
 
     if (restingUserId !== null && currentUserId === restingUserId) {
       return moment(restingEndTime, 'ddd, DD-MM-YYYY HH:mm:ss').toDate()

--- a/frontend/store/auth.js
+++ b/frontend/store/auth.js
@@ -73,10 +73,6 @@ export const actions = {
     const currentUserId = getters.getUserId
     const restingUserId = getters.getRestingUserId
 
-    console.log(restingEndTime)
-    console.log(currentUserId)
-    console.log(restingUserId)
-
     if (restingUserId !== null && currentUserId === restingUserId) {
       return moment(restingEndTime, 'ddd, DD-MM-YYYY HH:mm:ss').toDate()
     }

--- a/frontend/store/auth.js
+++ b/frontend/store/auth.js
@@ -5,6 +5,7 @@ export const state = () => ({
   id: null,
   isAuthenticated: false,
   isStaff: false,
+  restingUserId: null,
   restingEndTime: null
 })
 
@@ -25,10 +26,11 @@ export const mutations = {
     state.isStaff = isStaff
   },
   setRestingPeriod(state, endTime) {
-    const restingEndTime = moment(endTime).format('ddd, DD-MM-YYYY HH:mm:ss')
-    state.restingEndTime = restingEndTime
+    state.restingUserId = state.id
+    state.restingEndTime = endTime
   },
   clearRestingPeriod(state) {
+    state.restingUserId = null
     state.restingEndTime = null
   }
 }
@@ -46,22 +48,35 @@ export const getters = {
   isStaff(state) {
     return state.isStaff
   },
+  getRestingUserId(state) {
+    return state.restingUserId
+  },
   getRestingEndTime(state) {
-    if (state.restingEndTime !== null) {
-      return moment(state.restingEndTime, 'ddd, DD-MM-YYYY HH:mm:ss').toDate()
-    }
-    return null
+    return state.restingEndTime
   }
 }
 
 export const actions = {
   setRestingPeriod({ commit }) {
     const startTime = new Date()
-    const endTime = moment(startTime).add(5, 'm').toDate()
+    const endTime = moment(startTime).add(5, 'm').format('ddd, DD-MM-YYYY HH:mm:ss')
     commit('setRestingPeriod', endTime)
   },
-  clearRestingPeriod({ commit }) {
-    commit('clearRestingPeriod')
+  getRestingPeriod({ commit, getters }) {
+    const currentTime = new Date()
+    const restingEndTime = getters('getRestingEndTime')
+
+    if (currentTime >= restingEndTime) {
+      commit('clearRestingPeriod')
+    }
+
+    const currentUserId = getters('getUserId')
+    const restingUserId = getters('getRestingUserId')
+
+    if (restingUserId !== null && currentUserId === restingUserId) {
+      return moment(restingEndTime, 'ddd, DD-MM-YYYY HH:mm:ss').toDate()
+    }
+    return null
   },
   async authenticateUser({ commit }, authData) {
     try {


### PR DESCRIPTION
This PR aims to solve the minor issue where the resting message modal appears in any user account that is opened in the same computer after the first user finished annotation. Now, the resting message modal should only appear in the user account that should be resting, so if another user logs in then they won't get the message.

The limitation of the implementation is that, it can only remember the resting state of the last resting user. For example:
 - First Case (everything is fine in this case): Assume user A finishes annotating the whole project, they get the resting modal, and logs out. Then, user B logs in on the same computer, but doesn't finish annotating the whole project, and logs out (so user B is not yet in resting state). Next, user A logs in again, and here user A will still get the resting message if the resting period (which is 5 minutes) hasn't finished.
 - Second Case: Assume user A finishes annotating the whole project, they get the resting modal, and logs out. Then, user B logs in on the same computer, and **user B finishes annotating the whole project in less than 5 minutes**. Now, user B will get the resting modal. If user B logs out and then user A logs in again, user A should be still in resting state, but since the resting state has been overwritten, here user A does not get the resting modal. But I think this case is very unlikely to happen, and also not a very serious issue.

I have also fixed the bug in Others mode related to the "nie wiem" checkbox not clearing when user navigates to a new, unseen text. I believe the bug actually wasn't caused by recent changes in the code, but I'm not sure why it didn't appear earlier.

I also added some subheaders above the radio buttons in project creation, mostly because I kept forgetting to set the view option to single-text view as the radio buttons look similar with those of the mode setting 😅 :
<img width="960" alt="asdf" src="https://user-images.githubusercontent.com/64476430/198695227-401b5c65-a73e-4693-8260-dbe35a028489.PNG">

What's Changed:
 - frontend/components/tasks/toolbar/buttons/ButtonClear.vue : Very minor refactor, moved `:disabled="disabled"` to before `v-on` because I got a warning from that
 - frontend/components/project/FormCreate.vue : Added subheaders "Mode" and "View" above corresponding group of radio buttons
 - frontend/store/auth.js : Refactored code and add resting user id data
 - frontend/pages/projects/_id/affective-annotation/index.vue : Refactored code related to resting modal
 - frontend/pages/projects/index.vue : Refactored code related to resting modal
 - frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue : Clear checkbox if current value is not equal to null flag
 - frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue : Clear checkbox if current value is not equal to null flag