### PR TITLE
Feat: BE - new endpoint for showing all projects' progress

### DIFF
--- a/backend/projects/urls.py
+++ b/backend/projects/urls.py
@@ -1,12 +1,13 @@
 from django.urls import path
 
 from .views.member import MemberDetail, MemberList, MyRole
-from .views.project import ProjectDetail, ProjectList
+from .views.project import ProjectDetail, ProjectList, ProjectProgressDetail
 from .views.tag import TagDetail, TagList
 
 urlpatterns = [
     path(route="projects", view=ProjectList.as_view(), name="project_list"),
     path(route="projects/<int:project_id>", view=ProjectDetail.as_view(), name="project_detail"),
+    path(route="projects/progress", view=ProjectProgressDetail.as_view(), name="project_progress_detail"),
     path(route="projects/<int:project_id>/my-role", view=MyRole.as_view(), name="my_role"),
     path(route="projects/<int:project_id>/tags", view=TagList.as_view(), name="tag_list"),
     path(route="projects/<int:project_id>/tags/<int:tag_id>", view=TagDetail.as_view(), name="tag_detail"),


### PR DESCRIPTION
What's changed:
- `backend/projects/views/project.py`: added new view for listing all projects' progress
- `backend/projects/urls.py`: new endpoint added

The new endpoint is `localhost:8000/v1/projects/progress`. It will list all projects' progress of current logged in user. The format is below:
```
{
    "count": 25,
    "results": [
        {
            "project_id": 1,
            "total": 3,
            "remaining": 0,
            "complete": 3
        },
        {
            "project_id": 2,
            "total": 33,
            "remaining": 32,
            "complete": 1
        },
        {
            "project_id": 3,
            "total": 33,
            "remaining": 33,
            "complete": 0
        },
    ]
}
```
