### PR TITLE
feat: Implement validation to prevent confirming incomplete annotation

### DIFF
--- a/frontend/components/tasks/affectiveAnnotation/emotions/EmotionsInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/emotions/EmotionsInput.vue
@@ -135,51 +135,51 @@ export default {
     },
     generalPositivity: {
       type: Number,
-      default: 0
+      default: -99
     },
     generalNegativity: {
       type: Number,
-      default: 0
+      default: -99
     },
     joy: {
       type: Number,
-      default: 0
+      default: -99
     },
     admiration: {
       type: Number,
-      default: 0
+      default: -99
     },
     inspiration: {
       type: Number,
-      default: 0
+      default: -99
     },
     peace: {
       type: Number,
-      default: 0
+      default: -99
     },
     surprise: {
       type: Number,
-      default: 0
+      default: -99
     },
     sympathy: {
       type: Number,
-      default: 0
+      default: -99
     },
     fear: {
       type: Number,
-      default: 0
+      default: -99
     },
     sadness: {
       type: Number,
-      default: 0
+      default: -99
     },
     disgust: {
       type: Number,
-      default: 0
+      default: -99
     },
     anger: {
       type: Number,
-      default: 0
+      default: -99
     }
   },
 

--- a/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
@@ -33,6 +33,7 @@
           v-model="checkboxValue"
           :readonly="readOnly"
           :label="checkboxLabel"
+          @click="markClicked"
         />
       </v-col>
     </v-row>
@@ -58,7 +59,7 @@ export default {
     },
     value: {
       type: Number,
-      default: 0
+      default: -99
     },
     mustClick: {
       type: Boolean,
@@ -87,25 +88,18 @@ export default {
       mdiCheck,
       sliderMinVal: 0,
       sliderMaxVal: 10,
+      sliderThumbSize: 12,
       isClicked: false,
       enableSlider: true,
       checkboxValue: false,
-      nullFlag: -1
+      nullFlag: -1,
+      unclickedFlag: -99
     }
   },
 
   computed: {
-    sliderThumbSize() {
-      if (this.mustClick && this.value === 0) {
-        return (this.isClicked)? 12 : 0
-      }
-      return 12
-    },
     sliderThumbColor() {
-      if (this.mustClick && !this.isClicked && this.value < 0) {
-        return "transparent"
-      }
-      if (this.mustClick && this.isClicked && this.value < 0) {
+      if (this.mustClick && this.value < 0) {
         return "transparent"
       }
       return this.color
@@ -115,14 +109,21 @@ export default {
   watch: {
     value() {
       this.checkboxValue = this.hideSliderOnChecked && this.value === this.nullFlag
+      if (this.value === this.unclickedFlag) {
+        this.isClicked = false
+      }
     },
     checkboxValue(isChecked) {
       if (this.hideSliderOnChecked && isChecked) {
-        this.$emit('markCheckbox', this.categoryLabel)
+        if (this.isClicked) {
+          this.$emit('markCheckbox', this.categoryLabel)
+        }
         this.enableSlider = false
       }
       if (this.hideSliderOnChecked && !isChecked) {
-        this.$emit('unmarkCheckbox', this.categoryLabel)
+        if (this.isClicked) {
+          this.$emit('unmarkCheckbox', this.categoryLabel)
+        }
         this.enableSlider = true
       }
     }
@@ -133,7 +134,6 @@ export default {
       this.isClicked = true
     },
     valueChangeHandler(newValue) {
-      this.markClicked()
       this.$emit('change', newValue, this.categoryLabel)
     }
   }

--- a/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
@@ -42,6 +42,7 @@
           {{ question }}
         </v-card-title>
         <v-card-text  class="widget-dialog__text">
+          <p class="widget-dialog__hint">{{ $t('annotation.affectiveTextlabelHint') }}</p>
           <p class="widget-dialog__warning">{{ dialogErrorMessage }}</p>
           <seq2seq-box
             :text="text"

--- a/frontend/components/tasks/affectiveAnnotation/others/OthersInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/others/OthersInput.vue
@@ -179,43 +179,43 @@ export default {
     },
     ironic: {
       type: Number,
-      default: 0
+      default: -99
     },
     embarrassing: {
       type: Number,
-      default: 0
+      default: -99
     },
     vulgar: {
       type: Number,
-      default: 0
+      default: -99
     },
     politic: {
       type: Number,
-      default: 0
+      default: -99
     },
     interesting: {
       type: Number,
-      default: 0
+      default: -99
     },
     comprehensible: {
       type: Number,
-      default: 0
+      default: -99
     },
     agreeable: {
       type: Number,
-      default: 0
+      default: -99
     },
     believable: {
       type: Number,
-      default: 0
+      default: -99
     },
     sympathyToAuthor: {
       type: Number,
-      default: 0
+      default: -99
     },
     needMoreInfo: {
       type: Number,
-      default: 0
+      default: -99
     },
     wishToAuthor: {
       type: Array,

--- a/frontend/components/tasks/affectiveAnnotation/summary/SummaryInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/summary/SummaryInput.vue
@@ -74,7 +74,7 @@ export default {
   methods: {
     textValidation(value, arrayToCheck) {
       let errorMessage = ""
-      const pattern = /^[A-Za-z0-9ĄĆĘŁŃÓŚŹŻąćęłńóśźż, -]+$/
+      const pattern = /^[A-Za-z0-9ĄĆĘŁŃÓŚŹŻąćęłńóśźż -]+$/
       if (!pattern.test(value)) {
         errorMessage = this.$i18n.t('annotation.warningInvalidChar')
       }

--- a/frontend/i18n/de/projects/annotation.js
+++ b/frontend/i18n/de/projects/annotation.js
@@ -26,6 +26,7 @@ export default {
   warningInvalidChar: "Ungültiges Zeichen.",
   warningMaxCount: "Die maximale Anzahl wurde erreicht.",
   warningAlreadyWritten: "Wort ist bereits eingegeben.",
+  affectiveTextlabelHint: 'Bitte geben Sie jedes Schlüsselwort einzeln ein, indem Sie auf Ihrer Tastatur die Eingabetaste drücken. Erlaubte Zeichen: A-Z, a-z, polnische Buchstaben, 0-9, Leerzeichen (" ") und Bindestrich ("-").',
   affectiveSummary: {
     tagsQuestion: "Mit welchen Worten würden Sie diesen Text (Tags, Keywords) beschreiben? Bitte geben Sie 2-10 Wörter ein.",
     impressionsQuestion: "Welche Eindrücke/Emotionen/Gefühle löst dieser Text in Ihnen aus? Bitte geben Sie 2-10 Wörter ein."

--- a/frontend/i18n/de/projects/errors.js
+++ b/frontend/i18n/de/projects/errors.js
@@ -3,5 +3,6 @@ export default {
     'Die Datei(en) konnten nicht hochgeladen werden. Vielleicht ungültiges Format.\n Bitte prüfe die verfügbaren Dateiformate und folgende Datei(en): ',
   labelCannotCreate:
     'Das Label konnte nicht erstellt werden.\n Jeder Labelname und jedes Tastenkürzel kann nur einmal vergeben werden.',
-  invalidUserOrPass: 'Falscher Benutername oder falsches Passwort, oder etwas ist schief gelaufen.'
+  invalidUserOrPass: 'Falscher Benutername oder falsches Passwort, oder etwas ist schief gelaufen.',
+  incompleteAffectiveAnnotation: "Bitte stellen Sie sicher, dass Sie Ihre Antwort zu jeder Fragekategorie hinzugefügt haben. Stellen Sie sicher, dass Sie auf jeden verfügbaren Schieberegler (oder das Kontrollkästchen neben diesem Schieberegler, falls vorhanden) und jedes verfügbare Textfeld (oder das Kontrollkästchen neben diesem Textfeld, falls vorhanden) geklickt haben."
 }

--- a/frontend/i18n/en/projects/annotation.js
+++ b/frontend/i18n/en/projects/annotation.js
@@ -27,6 +27,7 @@ export default {
   warningInvalidChar: "Invalid character",
   warningMaxCount: "Maximum count has been reached",
   warningAlreadyWritten: "Word is already entered",
+  affectiveTextlabelHint: 'Please enter each keyword one by one by pressing "enter" on your keyboard. Allowed characters: A-Z, a-z, polish letters, 0-9, space (" "), and hyphen ("-").',
   affectiveSummary: {
     tagsQuestion: "What words would you describe this text (tags, keywords) with? Please enter 2-10 words",
     impressionsQuestion: "What impressions/emotions/feelings does this text evoke in you? Please enter 2-10 words",

--- a/frontend/i18n/en/projects/errors.js
+++ b/frontend/i18n/en/projects/errors.js
@@ -3,5 +3,6 @@ export default {
     'The file(s) could not be uploaded. Maybe invalid format.\n Please check available formats and the following file(s): ',
   labelCannotCreate:
     'The label could not be created.\n You cannot use the same label name or shortcut key.',
-  invalidUserOrPass: 'Incorrect username or password, or something went wrong.'
+  invalidUserOrPass: 'Incorrect username or password, or something went wrong.',
+  incompleteAffectiveAnnotation: "Please make sure that you have added your response to every question category. Make sure that you have clicked on every available slider (or the checkbox accompanying that slider, if any) and also answered every available textfield."
 }

--- a/frontend/i18n/fr/projects/annotation.js
+++ b/frontend/i18n/fr/projects/annotation.js
@@ -26,6 +26,7 @@ export default {
   warningInvalidChar: "Caractère non valide.",
   warningMaxCount: "Le nombre maximum a été atteint.",
   warningAlreadyWritten: "Le mot est déjà entré.",
+  affectiveTextlabelHint: 'Veuillez entrer chaque mot-clé un par un en appuyant sur "entrée" sur votre clavier. Caractères autorisés : A-Z, a-z, lettres polonaises, 0-9, espace (" ") et trait d\'union ("-").',
   affectiveSummary: {
     tagsQuestion: "Avec quels mots décririez-vous ce texte (tags, mots-clés)? Veuillez entrer 2 à 10 mots.",
     impressionsQuestion: "Quelles impressions/émotions/sentiments ce texte évoque-t-il en vous? Veuillez entrer 2 à 10 mots."

--- a/frontend/i18n/fr/projects/errors.js
+++ b/frontend/i18n/fr/projects/errors.js
@@ -3,5 +3,6 @@ export default {
     "Le fichier n'a pas pu être téléchargé. Peut-être un format non valide.\n Veuillez vérifier attentivement les formats disponibles.",
   labelCannotCreate:
     "L'étiquette n'a pas pu être créé.\n Vous ne pouvez pas utiliser le même nom d'étiquette ou la même raccourci clavier.",
-  invalidUserOrPass: "Nom d'utilisateur ou mot de passe incorrect, ou quelque chose a mal tourné."
+  invalidUserOrPass: "Nom d'utilisateur ou mot de passe incorrect, ou quelque chose a mal tourné.",
+  incompleteAffectiveAnnotation: "Assurez-vous d'avoir ajouté votre réponse à chaque catégorie de question. Assurez-vous que vous avez cliqué sur chaque curseur disponible (ou la case à cocher accompagnant ce curseur, le cas échéant) et chaque champ de texte disponible (ou la case à cocher accompagnant ce champ de texte, le cas échéant)."
 }

--- a/frontend/i18n/pl/projects/annotation.js
+++ b/frontend/i18n/pl/projects/annotation.js
@@ -27,6 +27,7 @@ export default {
   warningInvalidChar: "Nieprawidłowy znak.",
   warningMaxCount: "Osiągnięto maksymalną liczbę.",
   warningAlreadyWritten: "Słowo zostało już napisane.",
+  affectiveTextlabelHint: 'Wprowadź każde słowo kluczowe jedno po drugim, naciskając „enter” na klawiaturze. Dozwolone znaki: A-Z, a-z, polskie litery, 0-9, spacja (" ") i myślnik ("-").',
   affectiveSummary: {
     tagsQuestion: "Jakimi słowami opisałbyś ten tekst (tagi, słowa kluczowe)? Proszę wpisać 2-10 słów.",
     impressionsQuestion: "Jakie wrażenia/emocje/odczucia wzbudza w Tobie ten tekst? Proszę wpisać 2-10 słów."

--- a/frontend/i18n/pl/projects/errors.js
+++ b/frontend/i18n/pl/projects/errors.js
@@ -3,5 +3,6 @@ export default {
   'Plik(i) nie mogą zostać przesłane. Być może nieprawidłowy format. Sprawdź dostępne formaty i następujące pliki: ',
   labelCannotCreate:
   'Nie można utworzyć etykiety. Nie możesz użyć tej samej nazwy etykiety lub klawisza skrótu.',
-invalidUserOrPass: 'Nieprawidłowa nazwa użytkownika lub hasło albo coś poszło nie tak.'
+  invalidUserOrPass: 'Nieprawidłowa nazwa użytkownika lub hasło albo coś poszło nie tak.',
+  incompleteAffectiveAnnotation: "Upewnij się, że dodałeś odpowiedź do każdej kategorii pytań. Upewnij się, że kliknąłeś każdy dostępny suwak (lub pole wyboru towarzyszące temu suwakowi, jeśli istnieje), a także odpowiedziałeś na każde dostępne pole tekstowe."
 }

--- a/frontend/i18n/zh/projects/annotation.js
+++ b/frontend/i18n/zh/projects/annotation.js
@@ -27,6 +27,7 @@ export default {
   warningInvalidChar: "无效字符, ",
   warningMaxCount: "已达到最大计数, ",
   warningAlreadyWritten: "单词已经输入, ",
+  affectiveTextlabelHint: '请按键盘上的“回车”键一一输入每个关键字. 允许的字符: A-Z, a-z, 波兰字母, 0-9, 空格 (" ") 和连字符 ("-").',
   affectiveSummary: {
     tagsQuestion: "你会用什么词来描述这个文本 (标签、关键词)? 请输入2-10个字",
     impressionsQuestion: "这段文字唤起了你什么印象/情感/感受? 请输入2-10个字"

--- a/frontend/i18n/zh/projects/errors.js
+++ b/frontend/i18n/zh/projects/errors.js
@@ -1,5 +1,6 @@
 export default {
   fileCannotUpload: '这个文件不能被上传，获取格式错误，请仔细检查文件格式',
   labelCannotCreate: '这个标签不能被创建，你可能在其它的键上用了相同的标签名',
-  invalidUserOrPass: '用户名或者密码不正确'
+  invalidUserOrPass: '用户名或者密码不正确',
+  incompleteAffectiveAnnotation: "请确保您已将您的回答添加到每个问题类别。 确保您已单击每个可用的滑块（或该滑块随附的复选框，如果有）和每个可用的文本字段（或该文本字段随附的复选框，如果有）。"
 }


### PR DESCRIPTION
This PR solves two things: (1) Adding the validation mechanism in Summary, Emotions, and Others modes to prevent user from confirming current annotation and going to the next text when they haven't clicked on every slider (or haven't filled the textfields). A warning will appear when they try to do so, but it won't appear in admin account because it may be disturbing during debugging. (2) Some bug fixes related to sliders and checkboxes in Others mode.

What's changed:
 - frontend/pages/projects/_id/affective-annotation/index.vue : Add incomplete annotation validation for Summary, Emotions, Others modes.
 - frontend/i18n/* : Add text warning and its translations for incomplete annotation validation.
 - frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue : Prevent event emit when the value of the checkbox changes during transition to the next text, also add some other minor bug fixes.
 - frontend/components/tasks/affectiveAnnotation/emotions/EmotionsInput.vue : Set default values for sliders to -99. Previously, the default values were set to 0, making it difficult to distinguish a slider that hasn't been clicked at all from a slider that has loaded the value 0 from database. Now, it is possible to distinguish them in order to make the slider's thumb transparent in the case of an unclicked slider. Since the value -99 is only at the beginning when the slider hasn't been clicked at all, that value will not get stored into database.
 - frontend/components/tasks/affectiveAnnotation/others/OthersInput.vue : Similarly, set default values for sliders to -99.

Screenshots:
<img width="960" alt="ss1" src="https://user-images.githubusercontent.com/64476430/200073058-944ddfcc-a264-4124-bb5e-3c1abf884ac5.PNG">
The warning shown when a user tries to confirm without clicking/answering all categories.

<img width="960" alt="ss2" src="https://user-images.githubusercontent.com/64476430/200073083-8a149a75-88a6-49a6-b496-39bbbd088129.PNG">
Initial appearance of sliders that haven't been clicked and haven't loaded any value from db. The slider's thumb is not shown (transparent). This was the initial behavior of the sliders in early development, but got lost due to circumstances that arose from subsequent development that I didn't think about.
