### PR TITLE
fix: Make Emotions and Others inputs work in Combination mode

### DIFF
--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -532,6 +532,9 @@ export default {
         affectiveScaleLabelsJSON = EmotionsScales
       } else if (this.project.isOthersMode) {
         affectiveScaleLabelsJSON = OthersScales
+      } else if (this.project.isCombinationMode) {
+        affectiveScaleLabelsJSON.push(...EmotionsScales)
+        affectiveScaleLabelsJSON.push(...OthersScales)
       }
       const affectiveScalesDict = {}
       affectiveScaleLabelsJSON.forEach(function(item) {
@@ -764,6 +767,24 @@ export default {
           _.keys(this.affectiveScalesDict).length === _.keys(this.affectiveScalesValues).length &&
           this.affectiveOthersWishToAuthor.length > 0
         )
+      }
+      if (this.project.isCombinationMode) {
+        const affectiveEmotionsDict = Object.fromEntries(
+          Object.entries(this.affectiveScalesDict).map(([k, v]) => [v, k])
+        )
+        const keysMustExist = _.keys(this.affectiveScalesDict)
+        const keysAnswered = []
+        _.keys(this.affectiveScalesValues).forEach((key) => {
+          if (key !== "undefined") {
+            keysAnswered.push(affectiveEmotionsDict[key])
+          }
+        })
+        const output = (
+          keysMustExist.sort().join(',') === keysAnswered.sort().join(',') &&
+          this.affectiveSummaryTags.length >= 2 && this.affectiveSummaryImpressions.length >= 2 &&
+          this.affectiveOthersWishToAuthor.length > 0
+        )
+        return output
       }
       return true
     },


### PR DESCRIPTION
This PR aims to provide the fix to enable Emotions input and Others input work inside the Combination mode. The PR will be merged to the branch `feature/AffectiveAnnotationProject-combination-mode-fe` so that it can be integrated with the main implementation of the Combination mode.

What's changed:
 - frontend/pages/projects/_id/affective-annotation/index.vue : Added annotation checking mechanism for Summary, Emotions, and Others inputs for Combination mode

Screenshot:
I have tested the app in this branch, which is based on the branch `feature/AffectiveAnnotationProject-combination-mode-fe`, and now it works properly (at least on my machine). In the screenshot, it can be seen that the user is able to click the "confirm" button, and in the console it is shown that `keysMustExist` and `keysAnswered` (which refer to the dimensions that must be provided and the dimensions that have been clicked/responded, respectively) contain the same strings. Obviously, if the user hasn't clicked on every slider, they are unable to click the "confirm" button and proceed to the next text.

<img width="960" alt="ss-working1" src="https://user-images.githubusercontent.com/64476430/202136938-84da9b3c-cd4e-4b7c-963e-40794b54ebd4.PNG">
(all inputs added, the user can confirm)

<img width="960" alt="ss-working2" src="https://user-images.githubusercontent.com/64476430/202139083-f934c47a-e715-481b-b159-47e5e6b919ca.PNG">
(some inputs not added, the warning message is shown after the user tried to confirm)
