### PR TITLE
feat: FE - isCombinationMode

### DIFF
--- a/backend/label_types/views.py
+++ b/backend/label_types/views.py
@@ -93,7 +93,6 @@ class LabelUploadAPI(APIView):
 
     @transaction.atomic
     def post(self, request, *args, **kwargs):
-        print(request.data)
         if "file" not in request.data:
             raise ParseError("Empty content")
         try:

--- a/backend/label_types/views.py
+++ b/backend/label_types/views.py
@@ -93,6 +93,7 @@ class LabelUploadAPI(APIView):
 
     @transaction.atomic
     def post(self, request, *args, **kwargs):
+        print(request.data)
         if "file" not in request.data:
             raise ParseError("Empty content")
         try:

--- a/frontend/components/project/FormCreate.vue
+++ b/frontend/components/project/FormCreate.vue
@@ -118,12 +118,20 @@
             />
           </v-col>
           <v-col v-if="isAffectiveAnnotationProject" col="5">
-            <p class="font-weight-bold mb-0">Mode</p>
+            <p class="font-weight-bold mb-0">Mode combination</p>
+            <v-checkbox
+              :value="isCombinationMode"
+              :label="$t('overview.combinationMode')"
+              @change="updateValue('isCombinationMode', $event === true)"
+            />
+            <p class="font-weight-bold mb-0">Mode options</p>
             <v-radio-group 
+              :value="isCombinationMode ? '' : affectiveProjectMode"
               @change="updateValue('affectiveProjectMode', $event)"
             >
               <v-radio
                 v-for="(affectiveAnnotationOption, idx) in affectiveAnnotationOptions"
+                :disabled="isCombinationMode"
                 :key="idx"
                 :label="affectiveAnnotationOption.label"
                 :value="affectiveAnnotationOption.value"
@@ -212,6 +220,10 @@ export default Vue.extend({
       default: ''
     },
     isSingleAnnView: {
+      type: Boolean,
+      default: false
+    },
+    isCombinationMode: {
       type: Boolean,
       default: false
     },

--- a/frontend/components/project/FormCreate.vue
+++ b/frontend/components/project/FormCreate.vue
@@ -118,12 +118,6 @@
             />
           </v-col>
           <v-col v-if="isAffectiveAnnotationProject" col="5">
-            <p class="font-weight-bold mb-0">Mode combination</p>
-            <v-checkbox
-              :value="isCombinationMode"
-              :label="$t('overview.combinationMode')"
-              @change="updateValue('isCombinationMode', $event === true)"
-            />
             <p class="font-weight-bold mb-0">Mode options</p>
             <v-radio-group 
               :value="isCombinationMode ? '' : affectiveProjectMode"
@@ -131,14 +125,21 @@
             >
               <v-radio
                 v-for="(affectiveAnnotationOption, idx) in affectiveAnnotationOptions"
-                :disabled="isCombinationMode"
                 :key="idx"
+                :disabled="isCombinationMode"
                 :label="affectiveAnnotationOption.label"
                 :value="affectiveAnnotationOption.value"
               ></v-radio>
             </v-radio-group>
+            <p class="font-weight-bold mb-0">Mode settings</p>
+            <v-checkbox
+              :value="isCombinationMode"
+              :label="$t('overview.combinationMode')"
+              @change="updateValue('isCombinationMode', $event === true)"
+            />
             <p class="font-weight-bold mb-0">View</p>
             <v-radio-group
+              :value="isSingleAnnView"
               @change="updateValue('isSingleAnnView', $event)"
             >
               <v-radio

--- a/frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue
@@ -1,5 +1,6 @@
 <template>
-    <v-container class="humor-input widget">
+    <v-container class="humor-input widget" 
+        :class="{'--has-error': !value && showErrors, '--bordered': showBorders }">
         <v-row >
             <v-col v-if="scaleTypes.length && hasProperScaleTypes">
                 <h3 class="widget__title">{{ $t('annotation.humor.question')}}</h3>
@@ -163,6 +164,14 @@ export default Vue.extend({
         default: () => {}
     },
     readOnly: {
+        type: Boolean,
+        default: false
+    },
+    showErrors: {
+        type: Boolean,
+        default: false
+    },
+    showBorders: {
         type: Boolean,
         default: false
     },
@@ -444,6 +453,16 @@ export default Vue.extend({
 .humor-input {
     max-height: 400px;
     overflow-y: auto;
+
+    &.--bordered {
+        border: 2px solid #f0f0f0;
+        border-radius: 2px;  
+
+        &.--has-error {
+            border: 2px solid red;
+        }
+    }
+
 }
 
 .widget {

--- a/frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue
@@ -21,6 +21,7 @@
                                     :color="formData.subquestion1.isClicked ? 'primary' : 'grey'"
                                     :thumb-size="formData.subquestion1.isClicked ? 12 : 0"
                                     :thumb-color="formData.subquestion1.isClicked ? 'primary' : 'transparent'"
+                                    :track-color="formData.subquestion1.isClicked ? '' : 'grey'"
                                     ticks="always"
                                     ticks-size="3"
                                     :readonly="readOnly || formData.subquestion1.isSubmitting"
@@ -53,6 +54,7 @@
                                     :color="formData.subquestion2.isClicked ? 'primary' : 'grey'"
                                     :thumb-size="formData.subquestion2.isClicked ? 12 : 0"
                                     :thumb-color="formData.subquestion2.isClicked ? 'primary' : 'transparent'"
+                                    :track-color="formData.subquestion2.isClicked ? '' : 'grey'"
                                     ticks="always"
                                     min="0" 
                                     max="10" 
@@ -82,7 +84,7 @@
                                     <v-checkbox 
                                         v-model="substatement.isChecked" 
                                         :readonly="readOnly"
-                                        :disabled="!hasFilledTopQuestions"
+                                        :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
                                         :label="$t(`annotation.humor.subquestion3.substatement${(idx+1)}`)"
                                         class="subquestions-item__checkbox"
                                         @change="onLabelChange(substatement, `subquestion3`, idx)" />
@@ -92,7 +94,7 @@
                                         v-model="substatement.answer"
                                         :required="true"
                                         :readonly="readOnly"
-                                        :disabled="!hasFilledTopQuestions"
+                                        :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
                                         :question="$t(`annotation.humor.subquestion3.substatement${(idx+1)}Question`)"
                                         :full-question="`
                                             ${$t(`annotation.humor.subquestion3.substatement${(idx+1)}Question`)}
@@ -119,7 +121,7 @@
                                         <v-checkbox 
                                             v-model="substatement.isChecked" 
                                             :readonly="readOnly"
-                                            :disabled="!hasFilledTopQuestions"
+                                            :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
                                             :label="$t(`annotation.humor.subquestion4.substatement${(idx+1)}`)" 
                                             class="subquestions-item__checkbox"
                                             @change="onLabelChange(substatement, `subquestion4`, idx)"
@@ -187,126 +189,30 @@ export default Vue.extend({
             formData: {
                 subquestion1: {
                     value: 0,
-                    isChanged: false,
                     isClicked: false,
                     isSubmitting: false,
                 },
                 subquestion2: {
                     value: 0,
-                    isChanged: false,
                     isClicked: false,
                     isSubmitting: false,
                 },
-                subquestion3: [
-                    {
-                        isChecked: false,
-                        answer: ''
-                    }
-                ],
-                subquestion4: [
-                    {
-                        isChecked: false,
-                    }
-                ]
+                subquestion3: [],
+                subquestion4: []
             },
             originalFormData: {
                 subquestion1: {
                     value: 0,
-                    isChanged: false,
                     isClicked: false,
                     isSubmitting: false,
                 },
                 subquestion2: {
                     value: 0,
-                    isChanged: false,
                     isClicked: false,
                     isSubmitting: false,
                 },
-                subquestion3: [
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    }
-                ],
-                subquestion4: [
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                ]
+                subquestion3: [],
+                subquestion4: []
             }
         }
     },
@@ -334,7 +240,13 @@ export default Vue.extend({
                 Object.keys(annotation).forEach((subKey: string) => {
                     if(typeof annotation[subKey] === 'object') {
                         Object.keys(annotation[subKey]).every((subKey2: string) => {
-                            const isKey = annotation[subKey][subKey2] === textLabel.question
+                            let isKey = annotation[subKey][subKey2] === textLabel.question
+                            if(textLabel.question.includes(" - ")) {
+                                const questions = textLabel.question.split(" - ")
+                                isKey =
+                                    annotation[subKey].question === questions[0]
+                                    && annotation[subKey][subKey2] === questions[1]
+                            }
                             if(isKey) {
                                 substatementKey = `${subKey}.${subKey2}`
                             }
@@ -368,7 +280,7 @@ export default Vue.extend({
                 const scaleKeys = ['subquestion1', 'subquestion2']
                 const labelKeys = ['subquestion3', 'subquestion4']
                 const hasFilledScales = scaleKeys.some((scaleKey)=> {
-                    return val[scaleKey].isChanged
+                    return val[scaleKey].isClicked
                 })
                 const hasFilledAllScalesZeros = scaleKeys.every((scaleKey)=> {
                     return val[scaleKey].value === 0
@@ -399,7 +311,6 @@ export default Vue.extend({
                         const scaleValue = val.find((scale: any)=> scale.text === polishAnnotation)
                         if(scaleValue) {
                             _.set(this.formData, `${key}.value`, scaleValue.scale)
-                            _.set(this.formData, `${key}.isChanged`, true)
                             _.set(this.formData, `${key}.isClicked`, true)
                             _.set(this.formData, `${key}.isSubmitting`, false)
                         } 
@@ -419,6 +330,7 @@ export default Vue.extend({
             deep: true,
             handler(val) {
                 if(val.length) {
+                    const keys = ['subquestion3', 'subquestion4']
                     val.forEach((textLabel : any) => {
                         const substatementIndex = textLabel.substatementKey.split('.substatement')[1]
                         const subquestionIndex = textLabel.substatementKey.split(".")[0]
@@ -426,9 +338,24 @@ export default Vue.extend({
                         const formData = _.get(this.formData, formDataKey)
                         if(formData) {
                             _.set(this.formData, `${formDataKey}.isChecked`, !!textLabel.text)
+                            _.set(this.formData, `${formDataKey}.isSubmitting`, false)
                             _.set(this.formData, `${formDataKey}.answer`, textLabel.text)
-                        }
+                        } 
                     }) 
+                    keys.forEach((key)=> {
+                        // @ts-ignore
+                        const subquestionLength = this.formData[key].length
+                        for(let i : number= 0; i < subquestionLength; i++) {
+                            const substatementKey = `${key}.substatement${i+1}`
+                            const isStored = val.find((textLabel: any)=> textLabel.substatementKey === substatementKey)
+                            if(!isStored) {
+                                // @ts-ignore
+                                this.formData[key][i].answer = ''
+                                // @ts-ignore
+                                this.formData[key][i].isSubmitting = false
+                            }
+                        }
+                    })
                 } else {
                     this.formData = {
                         ...this.formData, 
@@ -442,18 +369,42 @@ export default Vue.extend({
             }
         }
     },
-    created() {
-        this.formData = _.cloneDeep(this.originalFormData)
+    async created() {
+        await this.setOriginalFormData()
+        this.$nextTick(()=> {
+            this.formData = _.cloneDeep(this.originalFormData)
+        })
     },
     mounted() {
         this.isLoaded = true;
     },
     methods: {
+        setOriginalFormData() {
+            const keys = ['subquestion3', 'subquestion4']
+            const annotation : any = this.polishAnnotation.humor
+            keys.forEach((key)=> {
+                let subquestionLength = 0
+                const substatement = Object.keys(annotation[key])
+                    .reverse()
+                    .find((annKey)=> annKey.includes('substatement'))
+                if(substatement) {
+                    subquestionLength = parseInt(substatement.replace( /^\D+/g, ''))
+                }
+                for(let i = 0; i < subquestionLength; i++) {
+                    // @ts-ignore
+                    this.originalFormData[key].push({
+                        isSubmitting: false,
+                        isChecked: false,
+                        answer: key === 'subquestion4' ? undefined : ""
+                    })
+                }
+            })
+        },
         onScaleChange: _.debounce(function (formDataKey: string) {
             // @ts-ignore
             const base = this as any
             _.set(base.formData, `${formDataKey}.isClicked`, true)
-            const formData : any = _.get(base.formData, formDataKey) || 0
+            const formData : any = _.get(base.formData, formDataKey) 
             const labelQuestion : string = base.polishAnnotation.humor[formDataKey]
             const scaleLabel : any = base.scaleTypes.find((scaleType: any)=> scaleType.text === labelQuestion)
             if(scaleLabel && base.isLoaded && !formData.isSubmitting) {
@@ -466,7 +417,8 @@ export default Vue.extend({
             const labelQuestionKey = `${key}.substatement${index+1}`
             const formData = _.get(this.formData, formDataKey)
             const labelQuestion = _.get(this.polishAnnotation.humor, labelQuestionKey)
-            const question = `${labelQuestion}`
+            const parentQuestion = _.get(this.polishAnnotation.humor, key+'.question')
+            const question = `${parentQuestion} - ${labelQuestion}`
 
             const textLabelValue = this.textLabelValues.find((textLabel : any) => textLabel.question === question)
             let eventName = textLabelValue ? 'update:label' : 'add:label'
@@ -482,6 +434,7 @@ export default Vue.extend({
                     const substatementId = textLabelValue.id
                     this.$emit(eventName, substatementId)
                 }
+                _.set(this.formData, formDataKey+".isSubmitting", !!answer)
             } 
         }
     }
@@ -513,23 +466,6 @@ export default Vue.extend({
     &.--visible {
         opacity: 1;
     }
-
-    .slider {
-        .v-slider__thumb {
-            opacity: .8;
-            background-color: white !important;
-            border: 1px solid #ddd !important; 
-        }
-
-        &.--has-filled {
-            .v-slider__thumb {
-                opacity: 1;
-                background-color: #1976d2 !important;
-                border-color: #1976d2 !important;
-            }
-        }
-    }
-
 
     &__slider {
         display: flex;

--- a/frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue
@@ -455,7 +455,7 @@ export default Vue.extend({
     overflow-y: auto;
 
     &.--bordered {
-        border: 2px solid #f0f0f0;
+        border: 2px solid #ddd;
         border-radius: 2px;  
 
         &.--has-error {

--- a/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
@@ -21,6 +21,7 @@
                                     :color="formData.subquestion1.isClicked ? 'primary' : 'grey'"
                                     :thumb-size="formData.subquestion1.isClicked ? 12 : 0"
                                     :thumb-color="formData.subquestion1.isClicked ? 'primary' : 'transparent'"
+                                    :track-color="formData.subquestion1.isClicked ? '' : 'grey'"
                                     ticks="always"
                                     ticks-size="3"
                                     :readonly="readOnly || formData.subquestion1.isSubmitting"
@@ -53,6 +54,7 @@
                                     :color="formData.subquestion2.isClicked ? 'primary' : 'grey'"
                                     :thumb-size="formData.subquestion2.isClicked ? 12 : 0"
                                     :thumb-color="formData.subquestion2.isClicked ? 'primary' : 'transparent'"
+                                    :track-color="formData.subquestion2.isClicked ? '' : 'grey'"
                                     ticks="always"
                                     min="0" 
                                     max="10" 
@@ -82,7 +84,7 @@
                                     <v-checkbox 
                                         v-model="substatement.isChecked" 
                                         :readonly="readOnly"
-                                        :disabled="!hasFilledTopQuestions"
+                                        :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
                                         :label="$t(`annotation.offensive.subquestion3.substatement${(idx+1)}`)"
                                         class="subquestions-item__checkbox"
                                         @change="onLabelChange(substatement, `subquestion3`, idx)" />
@@ -92,7 +94,7 @@
                                         v-model="substatement.answer"
                                         :required="true"
                                         :readonly="readOnly"
-                                        :disabled="!hasFilledTopQuestions"
+                                        :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
                                         :question="$t(`annotation.offensive.subquestion3.substatement${(idx+1)}Question`)"
                                         :full-question="`
                                             ${$t(`annotation.offensive.subquestion3.substatement${(idx+1)}Question`)}
@@ -119,7 +121,7 @@
                                         <v-checkbox 
                                             v-model="substatement.isChecked" 
                                             :readonly="readOnly"
-                                            :disabled="!hasFilledTopQuestions"
+                                            :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
                                             :label="$t(`annotation.offensive.subquestion4.substatement${(idx+1)}`)" 
                                             class="subquestions-item__checkbox"
                                             @change="onLabelChange(substatement, `subquestion4`, idx)"
@@ -187,105 +189,30 @@ export default Vue.extend({
             formData: {
                 subquestion1: {
                     value: 0,
-                    isChanged: false,
                     isClicked: false,
                     isSubmitting: false,
                 },
                 subquestion2: {
                     value: 0,
-                    isChanged: false,
                     isClicked: false,
                     isSubmitting: false,
                 },
-                subquestion3: [
-                    {
-                        isChecked: false,
-                        answer: ''
-                    }
-                ],
-                subquestion4: [
-                    {
-                        isChecked: false,
-                    }
-                ]
+                subquestion3: [],
+                subquestion4: []
             },
             originalFormData: {
                 subquestion1: {
                     value: 0,
-                    isChanged: false,
                     isClicked: false,
                     isSubmitting: false,
                 },
                 subquestion2: {
                     value: 0,
-                    isChanged: false,
                     isClicked: false,
                     isSubmitting: false,
                 },
-                subquestion3: [
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    },
-                    {
-                        isChecked: false,
-                        answer: ''
-                    }
-                ],
-                subquestion4: [
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                    {
-                        isChecked: false,
-                    },
-                ]
+                subquestion3: [],
+                subquestion4: []
             }
         }
     },
@@ -313,7 +240,13 @@ export default Vue.extend({
                 Object.keys(annotation).forEach((subKey: string) => {
                     if(typeof annotation[subKey] === 'object') {
                         Object.keys(annotation[subKey]).every((subKey2: string) => {
-                            const isKey = annotation[subKey][subKey2] === textLabel.question
+                            let isKey = annotation[subKey][subKey2] === textLabel.question
+                            if(textLabel.question.includes(" - ")) {
+                                const questions = textLabel.question.split(" - ")
+                                isKey =
+                                    annotation[subKey].question === questions[0]
+                                    && annotation[subKey][subKey2] === questions[1]
+                            }
                             if(isKey) {
                                 substatementKey = `${subKey}.${subKey2}`
                             }
@@ -347,7 +280,7 @@ export default Vue.extend({
                 const scaleKeys = ['subquestion1', 'subquestion2']
                 const labelKeys = ['subquestion3', 'subquestion4']
                 const hasFilledScales = scaleKeys.some((scaleKey)=> {
-                    return val[scaleKey].isChanged
+                    return val[scaleKey].isClicked
                 })
                 const hasFilledAllScalesZeros = scaleKeys.every((scaleKey)=> {
                     return val[scaleKey].value === 0
@@ -378,7 +311,6 @@ export default Vue.extend({
                         const scaleValue = val.find((scale: any)=> scale.text === polishAnnotation)
                         if(scaleValue) {
                             _.set(this.formData, `${key}.value`, scaleValue.scale)
-                            _.set(this.formData, `${key}.isChanged`, true)
                             _.set(this.formData, `${key}.isClicked`, true)
                             _.set(this.formData, `${key}.isSubmitting`, false)
                         } 
@@ -398,6 +330,7 @@ export default Vue.extend({
             deep: true,
             handler(val) {
                 if(val.length) {
+                    const keys = ['subquestion3', 'subquestion4']
                     val.forEach((textLabel : any) => {
                         const substatementIndex = textLabel.substatementKey.split('.substatement')[1]
                         const subquestionIndex = textLabel.substatementKey.split(".")[0]
@@ -405,9 +338,24 @@ export default Vue.extend({
                         const formData = _.get(this.formData, formDataKey)
                         if(formData) {
                             _.set(this.formData, `${formDataKey}.isChecked`, !!textLabel.text)
+                            _.set(this.formData, `${formDataKey}.isSubmitting`, false)
                             _.set(this.formData, `${formDataKey}.answer`, textLabel.text)
-                        }
+                        } 
                     }) 
+                    keys.forEach((key)=> {
+                        // @ts-ignore
+                        const subquestionLength = this.formData[key].length
+                        for(let i : number= 0; i < subquestionLength; i++) {
+                            const substatementKey = `${key}.substatement${i+1}`
+                            const isStored = val.find((textLabel: any)=> textLabel.substatementKey === substatementKey)
+                            if(!isStored) {
+                                // @ts-ignore
+                                this.formData[key][i].answer = ''
+                                // @ts-ignore
+                                this.formData[key][i].isSubmitting = false
+                            }
+                        }
+                    })
                 } else {
                     this.formData = {
                         ...this.formData, 
@@ -421,18 +369,42 @@ export default Vue.extend({
             }
         }
     },
-    created() {
-        this.formData = _.cloneDeep(this.originalFormData)
+    async created() {
+        await this.setOriginalFormData()
+        this.$nextTick(()=> {
+            this.formData = _.cloneDeep(this.originalFormData)
+        })
     },
     mounted() {
         this.isLoaded = true;
     },
     methods: {
+        setOriginalFormData() {
+            const keys = ['subquestion3', 'subquestion4']
+            const annotation : any = this.polishAnnotation.offensive
+            keys.forEach((key)=> {
+                let subquestionLength = 0
+                const substatement = Object.keys(annotation[key])
+                    .reverse()
+                    .find((annKey)=> annKey.includes('substatement'))
+                if(substatement) {
+                    subquestionLength = parseInt(substatement.replace( /^\D+/g, ''))
+                }
+                for(let i = 0; i < subquestionLength; i++) {
+                    // @ts-ignore
+                    this.originalFormData[key].push({
+                        isSubmitting: false,
+                        isChecked: false,
+                        answer: key === 'subquestion4' ? undefined : ""
+                    })
+                }
+            })
+        },
         onScaleChange: _.debounce(function (formDataKey: string) {
             // @ts-ignore
             const base = this as any
             _.set(base.formData, `${formDataKey}.isClicked`, true)
-            const formData : any = _.get(base.formData, formDataKey) || 0
+            const formData : any = _.get(base.formData, formDataKey) 
             const labelQuestion : string = base.polishAnnotation.offensive[formDataKey]
             const scaleLabel : any = base.scaleTypes.find((scaleType: any)=> scaleType.text === labelQuestion)
             if(scaleLabel && base.isLoaded && !formData.isSubmitting) {
@@ -445,7 +417,8 @@ export default Vue.extend({
             const labelQuestionKey = `${key}.substatement${index+1}`
             const formData = _.get(this.formData, formDataKey)
             const labelQuestion = _.get(this.polishAnnotation.offensive, labelQuestionKey)
-            const question = `${labelQuestion}`
+            const parentQuestion = _.get(this.polishAnnotation.offensive, key+'.question')
+            const question = `${parentQuestion} - ${labelQuestion}`
 
             const textLabelValue = this.textLabelValues.find((textLabel : any) => textLabel.question === question)
             let eventName = textLabelValue ? 'update:label' : 'add:label'
@@ -461,6 +434,7 @@ export default Vue.extend({
                     const substatementId = textLabelValue.id
                     this.$emit(eventName, substatementId)
                 }
+                _.set(this.formData, formDataKey+".isSubmitting", !!answer)
             } 
         }
     }
@@ -492,23 +466,6 @@ export default Vue.extend({
     &.--visible {
         opacity: 1;
     }
-
-    .slider {
-        .v-slider__thumb {
-            opacity: .8;
-            background-color: white !important;
-            border: 1px solid #ddd !important; 
-        }
-
-        &.--has-filled {
-            .v-slider__thumb {
-                opacity: 1;
-                background-color: #1976d2 !important;
-                border-color: #1976d2 !important;
-            }
-        }
-    }
-
 
     &__slider {
         display: flex;

--- a/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
@@ -455,7 +455,7 @@ export default Vue.extend({
     overflow-y: auto;
 
     &.--bordered {
-        border: 2px solid #f0f0f0;
+        border: 2px solid #ddd;
         border-radius: 2px;  
 
         &.--has-error {

--- a/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
@@ -1,5 +1,6 @@
 <template>
-    <v-container class="offensive-input widget">
+    <v-container class="offensive-input widget" 
+        :class="{'--has-error': !value && showErrors, '--bordered': showBorders }">
         <v-row >
             <v-col v-if="scaleTypes.length && hasProperScaleTypes">
                 <h3 class="widget__title">{{ $t('annotation.offensive.question')}}</h3>
@@ -163,6 +164,14 @@ export default Vue.extend({
         default: () => {}
     },
     readOnly: {
+        type: Boolean,
+        default: false
+    },
+    showErrors: {
+        type: Boolean,
+        default: false
+    },
+    showBorders: {
         type: Boolean,
         default: false
     },
@@ -444,6 +453,16 @@ export default Vue.extend({
 .offensive-input {
     max-height: 400px;
     overflow-y: auto;
+
+    &.--bordered {
+        border: 2px solid #f0f0f0;
+        border-radius: 2px;  
+
+        &.--has-error {
+            border: 2px solid red;
+        }
+    }
+
 }
 
 .widget {

--- a/frontend/domain/models/project/project.ts
+++ b/frontend/domain/models/project/project.ts
@@ -64,6 +64,9 @@ export class ProjectReadItem {
   @Expose({ name: 'is_single_ann_view' })
   isSingleAnnView: boolean
 
+  @Expose({ name: 'is_combination_mode' })
+  isCombinationMode: boolean
+
   @Expose({ name: 'is_text_project' })
   isTextProject: boolean
 
@@ -131,6 +134,7 @@ export class ProjectWriteItem {
     public is_offensive_mode: boolean,
     public is_others_mode: boolean,
     public is_single_ann_view: boolean,
+    public is_combination_mode: boolean,
     public tags: string[]
   ) {}
 
@@ -168,7 +172,8 @@ export class ProjectWriteItem {
       is_summary_mode: this.is_summary_mode,
       is_offensive_mode: this.is_offensive_mode,
       is_others_mode: this.is_others_mode,
-      is_single_ann_view: this.is_single_ann_view
+      is_single_ann_view: this.is_single_ann_view,
+      is_combination_mode: this.is_combination_mode
     }
   }
 }

--- a/frontend/i18n/de/projects/overview.js
+++ b/frontend/i18n/de/projects/overview.js
@@ -36,4 +36,5 @@ export default {
   enableOthers: 'Ermöglicht dem Benutzer die Messung anderer Parameter',
   articleViewMode: 'Anmerkung als Teil eines Artikels anzeigen',
   singleTextViewMode: 'Anmerkung als einzelnen Text anzeigen',
+  combinationMode: 'Alle Anmerkungsmodi kombinieren'
 }

--- a/frontend/i18n/en/projects/overview.js
+++ b/frontend/i18n/en/projects/overview.js
@@ -36,4 +36,5 @@ export default {
   enableOthers: 'Enable user to measure other parameters',
   articleViewMode: 'View annotation as part of an article',
   singleTextViewMode: 'View annotation as a single text',
+  combinationMode: 'Combine all annotation modes'
 }

--- a/frontend/i18n/fr/projects/overview.js
+++ b/frontend/i18n/fr/projects/overview.js
@@ -34,4 +34,5 @@ export default {
   enableOthers: "Permet à l'utilisateur de mesurer d'autres paramètres",
   articleViewMode: "Afficher l'annotation dans le cadre d'un article",
   singleTextViewMode: "Afficher l'annotation comme un seul texte",
+  combinationMode: "Combiner tous les modes d'annotation"
 }

--- a/frontend/i18n/pl/projects/overview.js
+++ b/frontend/i18n/pl/projects/overview.js
@@ -36,4 +36,5 @@ export default {
   enableOthers: 'Umożliwić użytkownikowi pomiar innych parametrów',
   articleViewMode: 'Wyświetl adnotację jako część artykułu',
   singleTextViewMode: 'Wyświetl adnotację jako pojedynczy tekst',
+  combinationMode: 'Połącz wszystkie tryby adnotacji'
 }

--- a/frontend/i18n/zh/projects/overview.js
+++ b/frontend/i18n/zh/projects/overview.js
@@ -28,4 +28,5 @@ export default {
   enableOthers: '使用户能够测量其他参数', 
   articleViewMode: '查看注释作为文章的一部分',
   singleTextViewMode: '查看注释为单个文本',
+  combinationMode: '结合所有注释模式'
 }

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -532,6 +532,9 @@ export default {
         affectiveScaleLabelsJSON = EmotionsScales
       } else if (this.project.isOthersMode) {
         affectiveScaleLabelsJSON = OthersScales
+      } else if (this.project.isCombinationMode) {
+        affectiveScaleLabelsJSON.push(...EmotionsScales)
+        affectiveScaleLabelsJSON.push(...OthersScales)
       }
       const affectiveScalesDict = {}
       affectiveScaleLabelsJSON.forEach(function(item) {
@@ -764,6 +767,24 @@ export default {
           _.keys(this.affectiveScalesDict).length === _.keys(this.affectiveScalesValues).length &&
           this.affectiveOthersWishToAuthor.length > 0
         )
+      }
+      if (this.project.isCombinationMode) {
+        const affectiveEmotionsDict = Object.fromEntries(
+          Object.entries(this.affectiveScalesDict).map(([k, v]) => [v, k])
+        )
+        const keysMustExist = _.keys(this.affectiveScalesDict)
+        const keysAnswered = []
+        _.keys(this.affectiveScalesValues).forEach((key) => {
+          if (key !== "undefined") {
+            keysAnswered.push(affectiveEmotionsDict[key])
+          }
+        })
+        const output = (
+          keysMustExist.sort().join(',') === keysAnswered.sort().join(',') &&
+          this.affectiveSummaryTags.length >= 2 && this.affectiveSummaryImpressions.length >= 2 &&
+          this.affectiveOthersWishToAuthor.length > 0
+        )
+        return output
       }
       return true
     },

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -733,7 +733,6 @@ export default {
     },
     async confirm() {
       if(this.project.isCombinationMode) {
-        // should be refactored
         this.hasValidEntries.isSummaryMode = this.isAllAffectiveDataAdded()
         this.hasValidEntries.isOthersMode = this.isAllAffectiveDataAdded()
         this.hasValidEntries.isEmotionsMode = this.isAllAffectiveDataAdded()

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -145,7 +145,7 @@
                 <v-divider />
                 <div v-if="isScaleImported" class="pa-4">
                   <summary-input
-                      v-if="project.isSummaryMode"
+                      v-if="project.isSummaryMode || project.isCombinationMode"
                       :text="doc.text"
                       :tags="affectiveSummaryTags"
                       :impressions="affectiveSummaryImpressions"
@@ -158,7 +158,7 @@
                       @add:impression="addImpression"
                     />
                     <emotions-input
-                      v-if="project.isEmotionsMode"
+                      v-if="project.isEmotionsMode || project.isCombinationMode"
                       :read-only="!canEdit"
                       :general-positivity="affectiveScalesValues.positive"
                       :general-negativity="affectiveScalesValues.negative"
@@ -175,7 +175,7 @@
                       @change="emotionsChangeHandler"
                     />
                     <others-input
-                      v-if="project.isOthersMode"
+                      v-if="project.isOthersMode || project.isCombinationMode"
                       :read-only="!canEdit"
                       :ironic="affectiveScalesValues.ironic"
                       :embarrassing="affectiveScalesValues.embarrassing"
@@ -198,7 +198,7 @@
                       @restore:wishToAuthor="restoreWishToAuthor"
                     />
                     <offensive-input
-                      v-if="project.isOffensiveMode"
+                      v-if="project.isOffensiveMode || project.isCombinationMode"
                       v-model="canConfirm"
                       :project="project"
                       :doc="doc"
@@ -211,7 +211,7 @@
                       @update:label="updateTag"
                       @remove:label="removeTag" />
                     <humor-input
-                      v-if="project.isHumorMode"
+                      v-if="project.isHumorMode || project.isCombinationMode"
                       v-model="canConfirm"
                       :project="project"
                       :doc="doc"
@@ -700,7 +700,9 @@ export default {
       }
     },
     async confirm() {
-      if(this.project.isSummaryMode || this.project.isOthersMode || this.project.isEmotionsMode) {
+      if(this.project.isCombinationMode) {
+        this.canConfirm = this.canConfirm && this.isAllAffectiveDataAdded()
+      } else if(this.project.isSummaryMode || this.project.isOthersMode || this.project.isEmotionsMode) {
         this.canConfirm = this.isAllAffectiveDataAdded()
       }
       this.hasClickedConfirmButton = this.canConfirm ? false : !this.isProjectAdmin

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -202,8 +202,8 @@
                     />
                     <offensive-input
                       v-if="project.isOffensiveMode || project.isCombinationMode"
-                      class="mb-10"
                       v-model="hasValidEntries.isOffensiveMode"
+                      class="mb-10"
                       :show-borders="project.isCombinationMode"
                       :show-errors="hasClickedConfirmButton"
                       :project="project"
@@ -218,8 +218,8 @@
                       @remove:label="removeTag" />
                     <humor-input
                       v-if="project.isHumorMode || project.isCombinationMode"
-                      class="mb-10"
                       v-model="hasValidEntries.isHumorMode"
+                      class="mb-10"
                       :show-borders="project.isCombinationMode"
                       :show-errors="hasClickedConfirmButton"
                       :project="project"
@@ -351,7 +351,7 @@ export default {
   },
 
   async fetch() {
-    // this.isProjectAdmin = await this.$services.member.isProjectAdmin(this.projectId)
+    this.isProjectAdmin = await this.$services.member.isProjectAdmin(this.projectId)
     await this.setProjectData()
     await this.setDoc()
     await this.setHasCheckedPreviousDoc()

--- a/frontend/pages/projects/create.vue
+++ b/frontend/pages/projects/create.vue
@@ -29,7 +29,7 @@ export default Vue.extend({
         allowOverlapping: false,
         graphemeMode: false,
         useRelation: false,
-        affectiveProjectMode: '',
+        affectiveProjectMode: 'isSummaryMode',
         isSingleAnnView: false,
         isCombinationMode: false,
         tags: [] as string[]
@@ -44,7 +44,7 @@ export default Vue.extend({
         allowOverlapping: false,
         graphemeMode: false,
         useRelation: false,
-        affectiveProjectMode: '',
+        affectiveProjectMode: 'isSummaryMode',
         isSingleAnnView: false,
         isCombinationMode: false,
         tags: [] as string[]
@@ -60,12 +60,11 @@ export default Vue.extend({
         if (!project.isSummaryMode) {
           await this.uploadScaleTypeFile(project)
         }
-      } /*
+      } 
       this.$router.push(`/projects/${project.id}`)
       this.$nextTick(() => {
         this.editedItem = Object.assign({}, this.defaultItem)
       })
-      */
     },
     getProjectItem() : ProjectWriteDTO {
       const editedItem : any = _.cloneDeep(this.editedItem)
@@ -82,21 +81,19 @@ export default Vue.extend({
       return editedItem
     },
     async getBlobScaleData(project: ProjectDTO) {
-      let fdata: Blob = new Blob([], {type: 'text/JSON'})
+      let fdata = []
       if(project.isCombinationMode) {
         const paths = {
           isEmotionsMode: '/formats/affective_annotation/affective_emotions_scales.json',
-          isOthersMode: '/formats/affective_annotation/affective_emotions_scales.json',
+          isOthersMode: '/formats/affective_annotation/affective_others_scales.json',
           isHumorMode: '/formats/affective_annotation/affective_humor_scales.json',
           isOffensiveMode: '/formats/affective_annotation/affective_offensive_scales.json'
         }
         const requests = Object.values(paths).map((path)=> fetch(path))
         const responses = await Promise.all(requests)
-        const jsonPromises = responses.map(async (response) => await response.json())
-        const labels = await Promise.all(jsonPromises)
-        const combinedLabels = [...labels.flat()]
-        fdata = new Blob([new Uint8Array(combinedLabels)], { type: "application/JSON" })
-        console.log(fdata)
+        const blobPromises = responses.map(async (response) => await response.blob())
+        const blobs = await Promise.all(blobPromises)
+        return [...blobs.flat()]
       } else {
         let selectedFile = ""
         if (project.isEmotionsMode) {
@@ -112,22 +109,23 @@ export default Vue.extend({
           selectedFile = '/formats/affective_annotation/affective_humor_scales.json'
         }
         const rawData = await fetch(selectedFile)
-        fdata = await rawData.blob()
-        console.log(fdata)
+        fdata = [await rawData.blob()]
       }
       return fdata
     },
     async uploadScaleTypeFile(project: ProjectDTO) {
-      const fdata : Blob = await this.getBlobScaleData(project)
-      const fname = "scales.json"
-      const fmetadata = { type: "application/JSON" }
-      const file = new File([fdata], fname, fmetadata)
-      try {
-        const projectId = project.id.toString()
-        await this.$services.scaleType.upload(projectId, file)
-      } catch (e) {
-        console.log(e.message)
-      }
+      const fdatas : Blob[] = await this.getBlobScaleData(project)
+      fdatas.forEach(async (fdata, index)=> {
+        const fname = `scales_${index}.json`
+        const fmetadata = { type: "application/JSON" }
+        const file = new File([fdata], fname, fmetadata)
+        try {
+          const projectId = project.id.toString()
+          await this.$services.scaleType.upload(projectId, file)
+        } catch (e) {
+          console.log(e.message)
+        }
+      })
     }
   }
 })

--- a/frontend/pages/projects/create.vue
+++ b/frontend/pages/projects/create.vue
@@ -31,6 +31,7 @@ export default Vue.extend({
         useRelation: false,
         affectiveProjectMode: '',
         isSingleAnnView: false,
+        isCombinationMode: false,
         tags: [] as string[]
       } as ProjectWriteDTO,
       defaultItem: {
@@ -45,6 +46,7 @@ export default Vue.extend({
         useRelation: false,
         affectiveProjectMode: '',
         isSingleAnnView: false,
+        isCombinationMode: false,
         tags: [] as string[]
       } as ProjectWriteDTO
     }
@@ -54,15 +56,16 @@ export default Vue.extend({
     async create() {
       const projectItem = this.getProjectItem()
       const project = await this.$services.project.create(projectItem)
-
-      if (project.isEmotionsMode || project.isOthersMode || project.isOffensiveMode|| project.isHumorMode) {
-        await this.importScaleTypeFile(project)
-      }
-
+      if(project.projectType === 'AffectiveAnnotation') {
+        if (!project.isSummaryMode) {
+          await this.uploadScaleTypeFile(project)
+        }
+      } /*
       this.$router.push(`/projects/${project.id}`)
       this.$nextTick(() => {
         this.editedItem = Object.assign({}, this.defaultItem)
       })
+      */
     },
     getProjectItem() : ProjectWriteDTO {
       const editedItem : any = _.cloneDeep(this.editedItem)
@@ -72,32 +75,55 @@ export default Vue.extend({
       const affectiveProjectModes = ['isHumorMode', 'isSummaryMode', 'isEmotionsMode',
         'isOthersMode', 'isOffensiveMode']
       affectiveProjectModes.forEach((key: string) => {
-        editedItem[key] = editedItem[key] ? editedItem[key] : false
+        const mode = editedItem[key] || false
+        editedItem[key] = this.editedItem.isCombinationMode ? false : mode
       })
       delete editedItem.affectiveProjectMode
       return editedItem
     },
-    async importScaleTypeFile(project: ProjectDTO) {
-      const projectId = project.id.toString()
-      let selectedFile = ""
-      if (project.isEmotionsMode) {
-        selectedFile = '/formats/affective_annotation/affective_emotions_scales.json'
+    async getBlobScaleData(project: ProjectDTO) {
+      let fdata: Blob = new Blob([], {type: 'text/JSON'})
+      if(project.isCombinationMode) {
+        const paths = {
+          isEmotionsMode: '/formats/affective_annotation/affective_emotions_scales.json',
+          isOthersMode: '/formats/affective_annotation/affective_emotions_scales.json',
+          isHumorMode: '/formats/affective_annotation/affective_humor_scales.json',
+          isOffensiveMode: '/formats/affective_annotation/affective_offensive_scales.json'
+        }
+        const requests = Object.values(paths).map((path)=> fetch(path))
+        const responses = await Promise.all(requests)
+        const jsonPromises = responses.map(async (response) => await response.json())
+        const labels = await Promise.all(jsonPromises)
+        const combinedLabels = [...labels.flat()]
+        fdata = new Blob([new Uint8Array(combinedLabels)], { type: "application/JSON" })
+        console.log(fdata)
+      } else {
+        let selectedFile = ""
+        if (project.isEmotionsMode) {
+          selectedFile = '/formats/affective_annotation/affective_emotions_scales.json'
+        }
+        if (project.isOthersMode) {
+          selectedFile = '/formats/affective_annotation/affective_others_scales.json'
+        }
+        if (project.isOffensiveMode) {
+          selectedFile = '/formats/affective_annotation/affective_offensive_scales.json'
+        }
+        if (project.isHumorMode) {
+          selectedFile = '/formats/affective_annotation/affective_humor_scales.json'
+        }
+        const rawData = await fetch(selectedFile)
+        fdata = await rawData.blob()
+        console.log(fdata)
       }
-      if (project.isOthersMode) {
-        selectedFile = '/formats/affective_annotation/affective_others_scales.json'
-      }
-      if (project.isOffensiveMode) {
-        selectedFile = '/formats/affective_annotation/affective_offensive_scales.json'
-      }
-      if (project.isHumorMode) {
-        selectedFile = '/formats/affective_annotation/affective_humor_scales.json'
-      }
-      const rawData = await fetch(selectedFile)
-      const fdata = await rawData.blob()
+      return fdata
+    },
+    async uploadScaleTypeFile(project: ProjectDTO) {
+      const fdata : Blob = await this.getBlobScaleData(project)
       const fname = "scales.json"
       const fmetadata = { type: "application/JSON" }
       const file = new File([fdata], fname, fmetadata)
       try {
+        const projectId = project.id.toString()
         await this.$services.scaleType.upload(projectId, file)
       } catch (e) {
         console.log(e.message)

--- a/frontend/services/application/project/projectApplicationService.ts
+++ b/frontend/services/application/project/projectApplicationService.ts
@@ -63,6 +63,7 @@ export class ProjectApplicationService {
       item.isOffensiveMode,
       item.isOthersMode,
       item.isSingleAnnView,
+      item.isCombinationMode,
       item.tags,
     )
   }

--- a/frontend/services/application/project/projectData.ts
+++ b/frontend/services/application/project/projectData.ts
@@ -29,6 +29,7 @@ export class ProjectDTO {
   affectiveProjectMode?: string
   isSingleAnnView: boolean
   isCompleted?: boolean
+  isCombinationMode: boolean
 
   constructor(item: ProjectReadItem) {
     this.id = item.id
@@ -57,6 +58,7 @@ export class ProjectDTO {
     this.isOffensiveMode = item.isOffensiveMode
     this.isEmotionsMode = item.isEmotionsMode
     this.isSingleAnnView = item.isSingleAnnView
+    this.isCombinationMode = item.isCombinationMode
   }
 }
 
@@ -81,6 +83,7 @@ export type ProjectWriteDTO = Pick<
   | 'isEmotionsMode'
   | 'isSingleAnnView'
   | 'isCompleted'
+  | 'isCombinationMode'
 > & { tags: string[] }
 
 export class ProjectListDTO {


### PR DESCRIPTION
Features added with this PR: 
- Ability to add an `AffectiveAnnotation` project with all modes combined
- Additional validation in HumorInput and OffensiveInput components 

What's changed: 
- `frontend/components/project/FormCreate.vue`: handle newly added `isCombinationMode`
- `frontend/components/tasks/affectiveAnnotation/*/*.vue`: 
--- adjusted the styling to make the sliders similar to the ones in `emotions` and `others` mode
--- added a new flag to disable the question when it is still submitting
--- added a function to set original form data array content dynamically
--- include the original subquestion to the substatement question
--- added the red border to inform user of errors in combination mode. Can be removed if its not oke XD I feel like that would be helping when we had 5 components and we don't know which one got the errors, what do you guys think?
- `frontend/i18n/*/projects/overview.js`: translations
- `frontend/domain/models/project/project.ts` handle newly added `isCombinationMode` in TS classes
- `frontend/services/application/project/projectData.ts`: handle newly added `isCombinationMode` in TS class
- `frontend/services/application/project/projectApplicationService.ts`: handle newly added `isCombinationMode` in TS class
- `frontend/pages/projects/create.vue`: adjusted the auto import function to automatically upload all files when `isCombinationMode is selected`
- `frontend/pages/projects/_id/affective-annotation/index.vue`: 
--- separated  `canConfirm`  values based on the components state

Notable: 
1. Now I added the original question to the key to prevent wrong mapping. OffensiveInput and HumorInput both got same questions (ex: Gender: What kind?), but different question above it, so I added the above question to the key and separated them with ` - `. I hope this approach is fine with the BE XD  Because I will need to know which question is which 
2. I haven't tested https://github.com/CLARIN-PL/doccano/pull/52, but this branch was coded before the PR was made, so the branch was made with the assumption that the code for the other mode components should be refactored. 

Screenshots: 
![image](https://user-images.githubusercontent.com/12537724/201761627-fdd4f038-6657-46d8-b023-5fb8febcb401.png)
![image](https://user-images.githubusercontent.com/12537724/201761966-7d9f20c3-5af0-4da8-bcb2-56ccf754f673.png)
