### PR TITLE
fix: Minor fixes for Affective Annotation UI

### DIFF
--- a/frontend/components/tasks/affectiveAnnotation/emotions/EmotionsInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/emotions/EmotionsInput.vue
@@ -240,7 +240,6 @@ export default {
 .emotions-input {
   word-wrap: normal;
   word-break: break-word;
-  max-height: 230px;
   overflow-y: auto;
   overflow-x: auto;
   width: 100%;

--- a/frontend/components/tasks/affectiveAnnotation/emotions/EmotionsInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/emotions/EmotionsInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="emotions-input">
+  <div class="emotions-input" :class="{'--has-error': showErrors, '--bordered': showBorders}">
     <p class="emotions-input__title">{{ $t('annotation.affectiveEmotions.titleQuestion') }}</p>
     <v-divider class="emotions-input__divider" />
     <p class="emotions-input__subheader">{{ $t('annotation.affectiveEmotions.titleWhat') }}</p>
@@ -133,6 +133,14 @@ export default {
       type: Boolean,
       default: false
     },
+    showErrors: {
+      type: Boolean,
+      default: false
+    },
+    showBorders: {
+      type: Boolean,
+      default: false
+    },
     generalPositivity: {
       type: Number,
       default: -99
@@ -233,17 +241,29 @@ export default {
   word-wrap: normal;
   word-break: break-word;
   max-height: 230px;
+  overflow-y: auto;
   overflow-x: auto;
   width: 100%;
-  padding-right: 20px !important;
+  padding: 15px 20px 10px 10px;
+
+  &.--bordered {
+    border: 2px solid #ddd;
+    border-radius: 2px;  
+
+    &.--has-error {
+      border: 2px solid red;
+    }
+  }
 
   &__title {
     font-size: 1.0rem;
+    font-weight: bold;
     line-height: 1.0;
   }
 
   &__subheader {
     font-size: 0.8rem;
+    font-weight: bold;
     line-height: 0.95;
     margin-top: 10px !important;
     margin-bottom: 0 !important;

--- a/frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue
@@ -451,7 +451,6 @@ export default Vue.extend({
 </script>
 <style lang="scss">
 .humor-input {
-    max-height: 400px;
     overflow-y: auto;
 
     &.--bordered {

--- a/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
@@ -201,6 +201,10 @@ export default {
       line-height: 0.95;
     }
 
+    &__question {
+      font-weight: bold;
+    }
+
     &__category {
       padding: 0 !important;
     }

--- a/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
@@ -451,7 +451,6 @@ export default Vue.extend({
 </script>
 <style lang="scss">
 .offensive-input {
-    max-height: 400px;
     overflow-y: auto;
 
     &.--bordered {

--- a/frontend/components/tasks/affectiveAnnotation/others/OthersInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/others/OthersInput.vue
@@ -329,7 +329,6 @@ export default {
 .others-input {
   word-wrap: normal;
   word-break: break-word;
-  max-height: 230px;
   overflow-y: auto;
   overflow-x: auto;
   width: 100%;

--- a/frontend/components/tasks/affectiveAnnotation/others/OthersInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/others/OthersInput.vue
@@ -1,6 +1,7 @@
 <template>
-  <div class="others-input">
+  <div class="others-input" :class="{'--has-error': showErrors, '--bordered': showBorders}">
     <p class="others-input__title">{{ $t('annotation.affectiveOthers.titleQuestion') }}</p>
+    <v-divider class="others-input__divider" />
     <div class="others-input__content">
       <slider
         :read-only="readOnly"
@@ -177,6 +178,14 @@ export default {
       type: Boolean,
       default: false
     },
+    showErrors: {
+      type: Boolean,
+      default: false
+    },
+    showBorders: {
+      type: Boolean,
+      default: false
+    },
     ironic: {
       type: Number,
       default: -99
@@ -321,18 +330,29 @@ export default {
   word-wrap: normal;
   word-break: break-word;
   max-height: 230px;
+  overflow-y: auto;
   overflow-x: auto;
   width: 100%;
-  padding-right: 20px !important;
+  padding: 15px 20px 10px 10px;
+
+  &.--bordered {
+    border: 2px solid #ddd;
+    border-radius: 2px;  
+
+    &.--has-error {
+      border: 2px solid red;
+    }
+  }
 
   &__title {
     font-size: 1.0rem;
+    font-weight: bold;
     line-height: 1.0;
-    margin-bottom: 0 !important;
   }
 
   &__subheader {
     font-size: 0.8rem;
+    font-weight: bold;
     line-height: 0.95;
     margin-top: 10px !important;
     margin-bottom: 0 !important;

--- a/frontend/components/tasks/affectiveAnnotation/summary/SummaryInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/summary/SummaryInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="summary-input" :class="{'--has-error': showErrors, '--bordered': showBorders}">
     <textfield-with-seq-2-seq
       :read-only="readOnly"
       :text="text"
@@ -39,6 +39,14 @@ export default {
       default: ""
     },
     readOnly: {
+      type: Boolean,
+      default: false
+    },
+    showErrors: {
+      type: Boolean,
+      default: false
+    },
+    showBorders: {
       type: Boolean,
       default: false
     },
@@ -116,3 +124,20 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.summary-input {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 10px;
+
+  &.--bordered {
+    border: 2px solid #ddd;
+    border-radius: 2px;  
+
+    &.--has-error {
+      border: 2px solid red;
+    }
+  }
+}
+</style>

--- a/frontend/components/tasks/affectiveAnnotation/summary/SummaryInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/summary/SummaryInput.vue
@@ -127,7 +127,6 @@ export default {
 
 <style lang="scss">
 .summary-input {
-  max-height: 400px;
   overflow-y: auto;
   padding: 10px;
 

--- a/frontend/components/tasks/seq2seq/Seq2seqBox.vue
+++ b/frontend/components/tasks/seq2seq/Seq2seqBox.vue
@@ -3,6 +3,7 @@
     <v-data-table
       :headers="headers"
       :items="annotations"
+      :no-data-text="$t('vuetify.noDataAvailable')"
       item-key="id"
       hide-default-header
       hide-default-footer

--- a/frontend/components/tasks/sidebar/AnnotationProgress.vue
+++ b/frontend/components/tasks/sidebar/AnnotationProgress.vue
@@ -40,3 +40,9 @@ export default Vue.extend({
   }
 })
 </script>
+
+<style>
+.v-list-item__title {
+  overflow: visible;
+}
+</style>

--- a/frontend/components/utils/RestingPeriodModal.vue
+++ b/frontend/components/utils/RestingPeriodModal.vue
@@ -32,7 +32,7 @@ import Vue from 'vue'
 export default Vue.extend({
   props: {
     endTime: {
-      type: Date,
+      type: String,
       required: true
     }
   },

--- a/frontend/i18n/de/generic.js
+++ b/frontend/i18n/de/generic.js
@@ -20,7 +20,7 @@ export default {
   onlyDisplayCompletedProject: "Derzeit werden {number} nicht abgeschlossene Projekte angezeigt. Abgeschlossene Projekte sind in der Liste nicht sichtbar.",
   restingMessage: {
     title: 'Zeit zum ausruhen!',
-    message1: 'Danke für deine Arbeit! Bitte trinken Sie einen Kaffee, bevor Sie fortfahren!',
+    message1: 'Danke für deine Arbeit!',
     message2: 'Sie können mit dem Kommentieren fortfahren:',
     message3: 'Bitte aktualisieren Sie diese Seite, wenn die Ruhezeit abgelaufen ist.'
   }

--- a/frontend/i18n/de/projects/annotation/sidebar.js
+++ b/frontend/i18n/de/projects/annotation/sidebar.js
@@ -1,7 +1,7 @@
 export default {
     progress: {
         title: 'Fortschritt',
-        total: 'Gesamt',
-        complete: 'Vollständig'
+        total: 'Gesamt Texte',
+        complete: 'Abgeschlossene Texte'
     },
 }

--- a/frontend/i18n/en/generic.js
+++ b/frontend/i18n/en/generic.js
@@ -21,7 +21,7 @@ export default {
   onlyDisplayCompletedProject: "Currently showing {number} uncompleted projects. Completed projects are not visible in the list.",
   restingMessage: {
     title: 'Time to rest!',
-    message1: 'Thank you for your work! Please have some coffee before continuing!',
+    message1: 'Thank you for your work!',
     message2: 'You can continue annotating at:',
     message3: 'Please refresh this page when the time to rest has ended.'
   }

--- a/frontend/i18n/en/projects/annotation/sidebar.js
+++ b/frontend/i18n/en/projects/annotation/sidebar.js
@@ -1,7 +1,7 @@
 export default {
     progress: {
         title: 'Progress',
-        total: 'Total',
-        complete: 'Complete'
+        total: 'Total Texts',
+        complete: 'Completed Texts'
     },
 }

--- a/frontend/i18n/fr/generic.js
+++ b/frontend/i18n/fr/generic.js
@@ -17,10 +17,10 @@ export default {
   description: 'Description',
   type: 'Type',
   loading: 'Chargement... veuillez patienter',
-  onlyDisplayCompletedProject: "Affiche actuellement {number} projets inachevés. Les projets terminés ne sont pas visibles dans la liste.",
+  onlyDisplayCompletedProject: "Affiche actuellement {number} projets inachevés. Les projets terminés ne sont pas visibles dans la liste.",
   restingMessage: {
     title: 'Temps de repos!',
-    message1: 'Merci pour votre travail! Prenez un café avant de continuer !',
+    message1: 'Merci pour votre travail!',
     message2: 'Vous pouvez continuer à annoter à :',
     message3: 'Veuillez actualiser cette page lorsque le temps de repos est terminé.'
   }

--- a/frontend/i18n/fr/projects/annotation/sidebar.js
+++ b/frontend/i18n/fr/projects/annotation/sidebar.js
@@ -1,7 +1,7 @@
 export default {
     progress: {
         title: 'Progrès',
-        total: 'Totale',
-        complete: 'Complet'
+        total: 'Textes Totaux',
+        complete: 'Textes Complétés'
     },
 }

--- a/frontend/i18n/pl/generic.js
+++ b/frontend/i18n/pl/generic.js
@@ -21,7 +21,7 @@ export default {
   onlyDisplayCompletedProject: "Obecnie pokazuje {number} nieukończonych projektów. Ukończone projekty nie są widoczne na liście.",
   restingMessage: {
     title: 'Czas na odpoczynek!',
-    message1: 'Dziękujemy za Twoją pracę! Proszę napić się kawy, zanim przejdziesz dalej!',
+    message1: 'Dziękujemy za Twoją pracę!',
     message2: 'Możesz kontynuować anotację od:',
     message3: 'Odśwież tę stronę, gdy czas na odpoczynek się skończy.'
   }

--- a/frontend/i18n/pl/projects/annotation/sidebar.js
+++ b/frontend/i18n/pl/projects/annotation/sidebar.js
@@ -1,7 +1,7 @@
 export default {
     progress: {
         title: 'Postęp',
-        total: 'Razem',
-        complete: 'Zakończono'
+        total: 'Razem Tekstów',
+        complete: 'Zakończono Tekstów'
     },
 }

--- a/frontend/i18n/zh/generic.js
+++ b/frontend/i18n/zh/generic.js
@@ -20,7 +20,7 @@ export default {
   onlyDisplayCompletedProject: "当前显示 {number} 个未完成的项目。已完成的项目在列表中不可见。",
   restingMessage: {
     title: '休息时间!',
-    message1: '感谢您的工作! 请先喝杯咖啡再继续!',
+    message1: '感谢您的工作!',
     message2: '您可以在此日期继续注释:',
     message3: '请在休息时间结束后刷新此页面.'
   }

--- a/frontend/i18n/zh/projects/annotation/sidebar.js
+++ b/frontend/i18n/zh/projects/annotation/sidebar.js
@@ -1,7 +1,7 @@
 export default {
     progress: {
         title: '进展',
-        total: '总计',
-        complete: '完成'
+        total: '总文本',
+        complete: '完成的文本'
     },
 }

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -337,7 +337,7 @@ export default {
       affectiveOthersWishToAuthor: [],
       affectiveOthersTmp: {},
       showRestingMessage: false,
-      restingEndTime: new Date(),
+      restingEndTime: "",
       hasCheckedPreviousDoc: false,
       hasValidEntries: {
         isSummaryMode: false,
@@ -479,6 +479,7 @@ export default {
       const restingEndTime = await this.calculateRestingPeriod()
       if (restingEndTime === null) {
         this.showRestingMessage = false
+        this.restingEndTime = ""
         return true
       } else {
         this.showRestingMessage = !this.isProjectAdmin

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -60,7 +60,7 @@ export default Vue.extend({
       selected: [] as ProjectDTO[],
       isLoading: false,
       showRestingMessage: false,
-      restingEndTime: new Date(),
+      restingEndTime: "",
     }
   },
 
@@ -93,6 +93,7 @@ export default Vue.extend({
       const restingEndTime = await this.calculateRestingPeriod()
       if (restingEndTime === null) {
         this.showRestingMessage = false
+        this.restingEndTime = ""
       } else {
         this.showRestingMessage = !this.isStaff
         this.restingEndTime = restingEndTime

--- a/frontend/store/user.js
+++ b/frontend/store/user.js
@@ -36,7 +36,7 @@ export const getters = {
   },
   getRestingEndTime(state) {
     if (state.restingEndTime !== null) {
-      return moment(state.restingEndTime, 'ddd, DD-MM-YYYY HH:mm:ss').toDate()
+      return moment(state.restingEndTime, 'DD-MM-YYYY HH:mm:ss').toDate()
     }
     return null
   }
@@ -48,7 +48,7 @@ export const actions = {
   },
   setRestingPeriod({ commit }) {
     const startTime = new Date()
-    const endTime = moment(startTime).add(5, 'm').format('ddd, DD-MM-YYYY HH:mm:ss')
+    const endTime = moment(startTime).add(5, 'm').format('DD-MM-YYYY HH:mm:ss')
     commit('setRestingPeriod', endTime)
   },
   calculateRestingPeriod({ commit, getters }) {
@@ -63,7 +63,7 @@ export const actions = {
       isRestingPeriodCleared = true
     }
     if (restingUserId !== null && currentUserId === restingUserId && !isRestingPeriodCleared) {
-      return restingEndTime
+      return moment(restingEndTime).format('DD-MM-YYYY HH:mm:ss')
     }
     return null
   },


### PR DESCRIPTION
This PR solves the following issues:
 - Rename strings in progress sidebar to "Razem tesktow", "Zakończono tesktow"
 - Add the box outline (border) for each dimension group
 - Remove the text about coffee in the break message, one date time only without info about GMT
 - Change "no data available" to "brak dostępnych danych"
 - Remove scroll bars from individual dimension groups (later it will allow to use just one scroll bar after text is made sticky on the top)

# Screenshots:
Resting Message
<img width="960" alt="fix1-restingMessage" src="https://user-images.githubusercontent.com/64476430/204088766-c5998463-adbd-4936-b3d1-65563e7b61af.PNG">

Sidebar
<img width="960" alt="fix2-progressBar" src="https://user-images.githubusercontent.com/64476430/204088769-8d7381b5-f223-4697-aca7-1585b7aff8ef.PNG">

No Data Available
<img width="454" alt="fix3-noDataAvailablePolish" src="https://user-images.githubusercontent.com/64476430/204088773-c3bdaa02-78a7-4c30-8f5d-0462ef9229bc.PNG">

Border for Each Dimension Group (note: the scroll bars haven't been removed when these screenshots were taken, but they have been removed now)
<img width="546" alt="fix4-borderNormal" src="https://user-images.githubusercontent.com/64476430/204088775-90bcf143-90a7-42b2-b624-242ec00706b2.PNG">
<img width="547" alt="fix4-borderErrors" src="https://user-images.githubusercontent.com/64476430/204088777-44d67242-8773-43f4-bb40-308a74f092a4.PNG">

# What's Changed:
 - frontend/i18n/* : Adjust strings for resting message, progress in sidebar
 - frontend/components/tasks/seq2seq/Seq2seqBox.vue : Add translations for "No data available" string
 - frontend/components/tasks/sidebar/AnnotationProgress.vue : Make overflow visible because otherwise "Zakończono Tekstów" will be clipped with ellipsis
 - frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue : Remove max height to hide scroll bar
 - frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue : Remove max height to hide scroll bar
 - frontend/components/tasks/affectiveAnnotation/summary/SummaryInput.vue : Add border
 - frontend/components/tasks/affectiveAnnotation/emotions/EmotionsInput.vue : Add border, remove max height, adjust style for consistency
 - frontend/components/tasks/affectiveAnnotation/others/OthersInput.vue : Add border, remove max height, adjust style for consistency
 - frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue : Adjust style for consistency
 - frontend/pages/projects/_id/affective-annotation/index.vue : Refactor `isAllAffectiveDataAdded()` into smaller functions to allow coloring red border on each individual dimension group on error, change resting time data type to string
 - frontend/store/user.js : Change return type of `calculateRestingPeriod` to string and remove timezone information
 - frontend/components/utils/RestingPeriodModal.vue : Change resting time data type to string
 - frontend/pages/projects/index.vue : Change resting time data type to string

