### PR TITLE
feat: Implement some additional improvements

### DIFF
--- a/frontend/components/questionnaires/GreetingCard.vue
+++ b/frontend/components/questionnaires/GreetingCard.vue
@@ -6,7 +6,7 @@
         <p>
             {{ $t('questionnaires_main.greetingsDetail')}}
         </p>
-        <v-btn @click="onStartButtonClick">
+        <v-btn color="primary" @click="onStartButtonClick">
             Start
         </v-btn>
     </v-card>

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -225,7 +225,7 @@ export default {
           }
         })
         this.$forceUpdate()
-
+        console.log("question.value: ", question.value)
         if (question.id && hasValue) {
           _.set(this.formData, `${formDataKey}.isSubmitting`, true)
           await this.$services.questionnaire.createAnswer({

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -225,7 +225,7 @@ export default {
           }
         })
         this.$forceUpdate()
-        console.log("question.value: ", question.value)
+
         if (question.id && hasValue) {
           _.set(this.formData, `${formDataKey}.isSubmitting`, true)
           await this.$services.questionnaire.createAnswer({

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -54,11 +54,12 @@
                           </div>
 
                           <div v-if="segment.questions">
-                            <ul>
+                            <ol :class="segment.prependIndex ? 'segment-question hide-list-style' : 'segment-question'">
                                 <li 
                                   v-for="(segmentQuestion, segQuIdx) in segment.questions" 
                                   :ref="`question_${segQuIdx}`"
-                                  :key="`segmentQuestion-${segQuIdx}`">
+                                  :key="`segmentQuestion-${segQuIdx}`"
+                                >
                                   <div v-if="segmentQuestion.id" class="question-container">
                                     <p v-if="segment.prependIndex">
                                       {{ segment.prependIndex+(segQuIdx+1) }}
@@ -86,7 +87,7 @@
                                     {{ $t('questionnaires_main.errorDataMapping') }}
                                   </p>
                                 </li>
-                            </ul>
+                            </ol>
                           </div>
                         </li>
                       </ul>
@@ -317,6 +318,10 @@ export default {
 
 .segment-description-container, .question-container {
   margin-bottom: 20px;
+}
+
+.hide-list-style {
+  list-style: none;
 }
 
 </style>

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -102,10 +102,10 @@
                 </v-card-text>
                 <v-card-actions>
                   <v-btn v-if="activeQuestionnaire+1 < formData.questionnaires.length" 
-                    @click="onClickContinueButton">
+                    color="primary" @click="onClickContinueButton">
                     {{ $t('questionnaires_main.buttonContinue') }}
                   </v-btn>
-                  <v-btn v-else @click="onClickFinishButton">
+                  <v-btn v-else color="primary" @click="onClickFinishButton">
                     {{ $t('questionnaires_main.buttonFinish') }}
                   </v-btn>
                 </v-card-actions>
@@ -116,7 +116,7 @@
       </div>
       <div v-else>
         {{ $t('questionnaires_main.errorNotFound') }}
-        <v-btn  @click="onClickFinishButton">
+        <v-btn color="primary" @click="onClickFinishButton">
           {{ $t('questionnaires_main.buttonFinish') }}
         </v-btn>
       </div>

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -41,11 +41,15 @@
                       </header>
 
                       <ul>
-                        <li v-for="(segment, segIdx) in questionnaire.segments" :key="`segment-${segIdx}`">
+                        <li
+                          v-for="(segment, segIdx) in questionnaire.segments"
+                          :key="`segment-${segIdx}`"
+                          class="hide-list-style"
+                        >
                           <div v-if="segment.scales" class="segment-description-container">
                             <p>
                               {{ segment.scales.description }}
-                              <ul>
+                              <ul class="hide-list-style">
                                 <li v-for="(segmentScaleValue, segScalIdx) in segment.scales.values" :key="`segmentScaleValue-${segScalIdx}`">
                                   {{ segmentScaleValue.value }} - {{ segmentScaleValue.text }}
                                 </li>
@@ -322,6 +326,7 @@ export default {
 
 .hide-list-style {
   list-style: none;
+  padding-left: 0 !important;
 }
 
 </style>

--- a/frontend/components/questionnaires/form/TextInput.vue
+++ b/frontend/components/questionnaires/form/TextInput.vue
@@ -14,7 +14,7 @@
           outlined
           readonly
           :value="showDialog ? '' : value"
-          :rules="config.numericOnly ? numericOnlyRules : rules"
+          :rules="textFieldRules"
           hide-details="auto"
         />
         <span v-show="errorMessage" class="error-message">
@@ -37,7 +37,7 @@
                 outlined
                 autofocus
                 :hint="$t('labels.clickEnter')"
-                :rules="config.numericOnly ? numericOnlyRules : rules"
+                :rules="textFieldRules"
                 @blur="onBlurTextField"
                 @keyup.enter="submitAnswer"
               />
@@ -123,13 +123,7 @@ export default {
       mdiSend,
       enableTextfield: true,
       showDialog: false,
-      dialogErrorMessage: '',
-      numericOnlyRules: [
-        (value) => {
-          const pattern = /^[0-9]+$/
-          return pattern.test(value) || this.$i18n.t('rules.inputTextRules.numericOnly')
-        }
-      ]
+      dialogErrorMessage: ''
     }
   },
 
@@ -141,6 +135,16 @@ export default {
       set(val) {
         this.$emit('input', val)
       }
+    },
+    textFieldRules() {
+      const { numericOnly } = this.config
+      const numericOnlyRules = [
+        (value) => {
+          const pattern = /^[0-9]+$/
+          return pattern.test(value) || this.$i18n.t('rules.inputTextRules.numericOnly')
+        }
+      ]
+      return numericOnly ? this.rules.concat(numericOnlyRules) : this.rules
     }
   },
   methods: {

--- a/frontend/components/questionnaires/form/TextInput.vue
+++ b/frontend/components/questionnaires/form/TextInput.vue
@@ -33,7 +33,7 @@
           <v-row justify="center" align="top">
             <v-col cols="10">
               <v-text-field
-                v-model.trim="textInput"
+                v-model.trim="text"
                 outlined
                 autofocus
                 :hint="$t('labels.clickEnter')"
@@ -142,8 +142,8 @@ export default {
     }
   },
   watch: {
-    textInput() {
-      this.text = this.textInput
+    value() {
+      this.text = this.value
     }
   },
   methods: {

--- a/frontend/components/questionnaires/form/TextInput.vue
+++ b/frontend/components/questionnaires/form/TextInput.vue
@@ -144,7 +144,6 @@ export default {
   watch: {
     textInput() {
       this.text = this.textInput
-      console.log(this.text)
     }
   },
   methods: {
@@ -152,15 +151,16 @@ export default {
       this.$emit('blur', this.text)
     },
     submitAnswer() {
-      console.log("submitAnswer, this.textAnswer: ", this.text)
       const { numericOnly } = this.config
       const numericPattern = /^[0-9]+$/
       const hasFilledText = this.required ? !!this.text : true
       const hasFilledNumericOnly = numericOnly ? numericPattern.test(this.text) : true
       if (hasFilledText && hasFilledNumericOnly) {
         this.showDialog = false
-        this.$emit('change', { ...this.passedData, value: this.text })
-        this.$emit('submit', this.text)
+        const passedData = JSON.parse(JSON.stringify(this.passedData))
+        passedData.question.value = this.text
+        this.$emit('change', { ...passedData, value: passedData.question.value })
+        this.$emit('submit', passedData.question.value)
       } else {
         if (!hasFilledText) {
           this.dialogErrorMessage = this.$t('rules.required')

--- a/frontend/components/questionnaires/form/TextInput.vue
+++ b/frontend/components/questionnaires/form/TextInput.vue
@@ -127,7 +127,7 @@ export default {
       numericOnlyRules: [
         (value) => {
           const pattern = /^[0-9]+$/
-          return pattern.test(value) || this.$i18n.t('annotation.warningInvalidChar')
+          return pattern.test(value) || this.$i18n.t('rules.inputTextRules.numericOnly')
         }
       ]
     }

--- a/frontend/components/questionnaires/form/TextInput.vue
+++ b/frontend/components/questionnaires/form/TextInput.vue
@@ -152,13 +152,22 @@ export default {
       this.$emit('blur', this.text)
     },
     submitAnswer() {
+      const { numericOnly } = this.config
+      const numericPattern = /^[0-9]+$/
       const hasFilledText = this.required ? !!this.text : true
-      if (hasFilledText) {
+      console.log("this.text: ", this.text)
+      const hasFilledNumericOnly = numericOnly ? numericPattern.test(this.text) : true
+      if (hasFilledText && hasFilledNumericOnly) {
         this.showDialog = false
         this.$emit('change', { ...this.passedData, value: this.text })
         this.$emit('submit', this.text)
       } else {
-        this.dialogErrorMessage = this.$t('rules.required')
+        if (!hasFilledText) {
+          this.dialogErrorMessage = this.$t('rules.required')
+        }
+        if (!hasFilledNumericOnly) {
+          this.dialogErrorMessage = this.$i18n.t('rules.inputTextRules.numericOnly')
+        }
       }
     },
     textfieldClickHandler() {

--- a/frontend/components/questionnaires/form/TextInput.vue
+++ b/frontend/components/questionnaires/form/TextInput.vue
@@ -14,7 +14,7 @@
           outlined
           readonly
           :value="showDialog ? '' : value"
-          :rules="rules"
+          :rules="config.numericOnly ? numericOnlyRules : rules"
           hide-details="auto"
         />
         <span v-show="errorMessage" class="error-message">
@@ -37,7 +37,7 @@
                 outlined
                 autofocus
                 :hint="$t('labels.clickEnter')"
-                :rules="rules"
+                :rules="config.numericOnly ? numericOnlyRules : rules"
                 @blur="onBlurTextField"
                 @keyup.enter="submitAnswer"
               />
@@ -68,6 +68,14 @@ import { mdiSend } from '@mdi/js'
 export default {
   name: 'TextInput',
   props: {
+    config: {
+      type: Object,
+      default() {
+        return {
+          numericOnly: false
+        }
+      }
+    },
     disabled: {
       type: Boolean,
       default: false
@@ -115,7 +123,13 @@ export default {
       mdiSend,
       enableTextfield: true,
       showDialog: false,
-      dialogErrorMessage: ''
+      dialogErrorMessage: '',
+      numericOnlyRules: [
+        (value) => {
+          const pattern = /^[0-9]+$/
+          return pattern.test(value) || this.$i18n.t('annotation.warningInvalidChar')
+        }
+      ]
     }
   },
 

--- a/frontend/components/questionnaires/form/TextInput.vue
+++ b/frontend/components/questionnaires/form/TextInput.vue
@@ -33,7 +33,7 @@
           <v-row justify="center" align="top">
             <v-col cols="10">
               <v-text-field
-                v-model.trim="text"
+                v-model.trim="textInput"
                 outlined
                 autofocus
                 :hint="$t('labels.clickEnter')"
@@ -123,19 +123,13 @@ export default {
       mdiSend,
       enableTextfield: true,
       showDialog: false,
-      dialogErrorMessage: ''
+      dialogErrorMessage: '',
+      textInput: '',
+      text: ''
     }
   },
 
   computed: {
-    text: {
-      get() {
-        return this.value
-      },
-      set(val) {
-        this.$emit('input', val)
-      }
-    },
     textFieldRules() {
       const { numericOnly } = this.config
       const numericOnlyRules = [
@@ -147,15 +141,21 @@ export default {
       return numericOnly ? this.rules.concat(numericOnlyRules) : this.rules
     }
   },
+  watch: {
+    textInput() {
+      this.text = this.textInput
+      console.log(this.text)
+    }
+  },
   methods: {
     onBlurTextField() {
       this.$emit('blur', this.text)
     },
     submitAnswer() {
+      console.log("submitAnswer, this.textAnswer: ", this.text)
       const { numericOnly } = this.config
       const numericPattern = /^[0-9]+$/
       const hasFilledText = this.required ? !!this.text : true
-      console.log("this.text: ", this.text)
       const hasFilledNumericOnly = numericOnly ? numericPattern.test(this.text) : true
       if (hasFilledText && hasFilledNumericOnly) {
         this.showDialog = false

--- a/frontend/i18n/de/rules.js
+++ b/frontend/i18n/de/rules.js
@@ -1,5 +1,8 @@
 export default {
   required: 'Benötigt',
+  inputTextRules: {
+    numericOnly: 'Bitte verwenden Sie nur Ziffern (0-9) Zeichen'
+  },
   colorRules: {
     colorRequired: 'Farbe wird benötigt'
   },

--- a/frontend/i18n/en/rules.js
+++ b/frontend/i18n/en/rules.js
@@ -1,5 +1,8 @@
 export default {
   required: 'Required',
+  inputTextRules: {
+    numericOnly: 'Please use only numeric (0-9) characters'
+  },
   colorRules: {
     colorRequired: 'Color is required'
   },

--- a/frontend/i18n/fr/rules.js
+++ b/frontend/i18n/fr/rules.js
@@ -1,5 +1,8 @@
 export default {
   required: 'Obligatoire',
+  inputTextRules: {
+    numericOnly: "Veuillez n'utiliser que des caractères numériques (0-9)"
+  },
   colorRules: {
     colorRequired: 'La couleur est obligatoire'
   },

--- a/frontend/i18n/pl/rules.js
+++ b/frontend/i18n/pl/rules.js
@@ -1,5 +1,8 @@
 export default {
   required: 'Wymagany',
+  inputTextRules: {
+    numericOnly: 'Proszę używać tylko znaków numerycznych (0-9).'
+  },
   colorRules: {
     colorRequired: 'Kolor jest wymagany'
   },

--- a/frontend/i18n/zh/rules.js
+++ b/frontend/i18n/zh/rules.js
@@ -1,5 +1,8 @@
 export default {
   required: '请输入',
+  inputTextRules: {
+    numericOnly: '请仅使用数字 (0-9) 字符'
+  },
   colorRules: {
     colorRequired: '请输入颜色'
   },

--- a/frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js
+++ b/frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js
@@ -384,6 +384,7 @@ export const qTypes = [
                                 type: "text",
                                 header: "[Wielkość gospodarstwa domowego]",
                                 text: "Ile osób, łącznie z Panem/Panią, mieszka w gospodarstwie domowym?",
+                                numericOnly: true,
                             },
                             {
                                 type: "radio",

--- a/frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js
+++ b/frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js
@@ -214,6 +214,7 @@ export const qTypes = [
                                 type: "text",
                                 header: "[Wiek]",
                                 text: "Jaki jest Pana/Pani wiek w latach (proszę wpisać tylko liczbę)?",
+                                numericOnly: true,
                             },
                             {
                                 type: "text",

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -208,6 +208,10 @@ export function mapQuestionnaireTypes(qTypes) {
                             maxLabel: question.maxLabel,
                             showTickLabels: question.showTickLabels ?? true
                         }
+                    } else if(question.type === "text" || question.type === "radio") {
+                        question.config = {
+                            numericOnly: question.numericOnly ?? false
+                        }
                     }
                     
                     question.rules = []


### PR DESCRIPTION
 1. Replace `ul` with `ol`, with optional class to hide list item symbol
 2. Add button color
 3. Added warning message if textfield should be numeric only. However, currently user is not actually prevented to enter such invalid characters, we only show the warning message. This is because when I tried to add validation mechanism inside `submitAnswer()` function to prevent submitting non-numeric chars, it was strangely buggy, so currently this is the best I can do within the time limit (the bug desc below).

What's changed:
 - frontend/components/questionnaires/GreetingCard.vue : Add button color
 - frontend/components/questionnaires/QuestionnaireForm.vue : Minor styling
 - frontend/components/questionnaires/form/TextInput.vue : Add config prop to indicate numeric-only textfield, Add rules for numeric only textfield
 - frontend/utils/questionnaires.js : Add config prop to indicate numeric-only textfield
 - frontend/i18n/* : Add translations for warning message
 - frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js : Add numericOnly field

Screenshots:
<img width="960" alt="Capture" src="https://user-images.githubusercontent.com/64476430/205314020-98d12e97-6510-4a8c-b60d-cc4f5b101aa1.PNG">
<img width="960" alt="1" src="https://user-images.githubusercontent.com/64476430/205318592-cef3561f-9439-4baf-bdb4-01cf1ce7574e.PNG">
<img width="960" alt="2" src="https://user-images.githubusercontent.com/64476430/205318599-9d199cd7-2610-4604-bcd4-e6bff71c936e.PNG">


