### PR TITLE
fix: Make TextInput work when inside dynamic component, correct week and month diff calculation

### DIFF
--- a/frontend/components/questionnaires/form/TextInput.vue
+++ b/frontend/components/questionnaires/form/TextInput.vue
@@ -157,10 +157,15 @@ export default {
       const hasFilledNumericOnly = numericOnly ? numericPattern.test(this.text) : true
       if (hasFilledText && hasFilledNumericOnly) {
         this.showDialog = false
-        const passedData = JSON.parse(JSON.stringify(this.passedData))
-        passedData.question.value = this.text
-        this.$emit('change', { ...passedData, value: passedData.question.value })
-        this.$emit('submit', passedData.question.value)
+        let passedData = null
+        if (this.passedData) {
+          passedData = JSON.parse(JSON.stringify(this.passedData))
+          passedData.question.value = this.text
+        }
+        console.log(this.text)
+        console.log(passedData)
+        this.$emit('change', { ...passedData, value: this.text })
+        this.$emit('submit', this.text)
       } else {
         if (!hasFilledText) {
           this.dialogErrorMessage = this.$t('rules.required')

--- a/frontend/components/questionnaires/form/TextInput.vue
+++ b/frontend/components/questionnaires/form/TextInput.vue
@@ -162,8 +162,6 @@ export default {
           passedData = JSON.parse(JSON.stringify(this.passedData))
           passedData.question.value = this.text
         }
-        console.log(this.text)
-        console.log(passedData)
         this.$emit('change', { ...passedData, value: this.text })
         this.$emit('submit', this.text)
       } else {

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -307,7 +307,6 @@ export function getQuestionnairesToShow() {
     catch(error) {
         console.error(error)
     }
-    console.log(toShow)
     return toShow
 }
 

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -253,8 +253,9 @@ export function getQuestionnairesToShow() {
                 const { firstLoginTime } = getters['user/getLogin']
                 const { hasAnnotatedToday, textCountToday } = getters['user/getAnnotation']
                 const { hasFinishedAll } = getters['user/getProject'] 
-                const monthDiff = moment(firstLoginTime, DATE_FORMAT)
-                                    .diff(moment(todayTime), 'months')
+                const monthDiff = moment(todayTime).diff(
+                    moment(firstLoginTime, DATE_FORMAT), 'months'
+                )
                 const hasPassedResearchTime = monthDiff >= RESEARCH_TIME_IN_MONTHS
                 let isShowing = false
                 if(questionnaireType.id === '1.1') {
@@ -269,8 +270,8 @@ export function getQuestionnairesToShow() {
                                 && hasFinishedAll 
                                 && hasPassedResearchTime
                 } else if(questionnaireType.id === "3.1") {
-                    const weekDiff = moment(firstLoginTime, DATE_FORMAT)
-                                    .diff(moment(todayTime), 'weeks')
+                    const weekDiff = moment(todayTime)
+                                    .diff(moment(firstLoginTime, DATE_FORMAT), 'weeks')
                     const hasPassedOneWeek = weekDiff >= 1
                     isShowing = !isFilled && hasPassedOneWeek
                 } else if(questionnaireType.id === "3.2") {
@@ -291,8 +292,8 @@ export function getQuestionnairesToShow() {
                                 && hasFinishedAll
                                 && hasPassedResearchTime
                 } else if(questionnaireType.id === "6.1") {
-                    const weekDiff = moment(firstLoginTime, DATE_FORMAT)
-                                    .diff(moment(todayTime), 'weeks')
+                    const weekDiff = moment(todayTime)
+                                    .diff(moment(firstLoginTime, DATE_FORMAT), 'weeks')
                     const hasPassedTwoWeeks = weekDiff >= 2
                     isShowing = !isFilled && hasPassedTwoWeeks
                 }
@@ -306,6 +307,7 @@ export function getQuestionnairesToShow() {
     catch(error) {
         console.error(error)
     }
+    console.log(toShow)
     return toShow
 }
 


### PR DESCRIPTION
What's changed:
 - frontend/components/questionnaires/form/TextInput.vue : Add check if `this.passedData` is undefined, which is the case when TextInput is used inside RadioInput and SelectInput.
 - frontend/utils/questionnaires.js : Correct `monthDiff` and `weekDiff` calculation, previously the difference results in negative values. Now it should be positive and the check should work correctly. I think I have fixed this but the change got discarded when I was debugging and I forgot about it. I apologize about that.