### PR TITLE
fix: Make questionnaire navigation locale-aware, add scroll to top button

### DIFF
--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -341,13 +341,13 @@ export default {
         )
         if (hasClickedEverything) {
           this.resetQuestionnaire()
-          this.$router.push('/questionnaires')
+          this.$router.push(this.localePath('/questionnaires'))
         } else {
           this.scrollToFaultyQuestion(questions)
         }
       } else {
         this.resetQuestionnaire()
-        this.$router.push('/questionnaires')
+        this.$router.push(this.localePath('/questionnaires'))
       }
     }
   }

--- a/frontend/i18n/de/generic.js
+++ b/frontend/i18n/de/generic.js
@@ -23,5 +23,6 @@ export default {
     message1: 'Danke für deine Arbeit!',
     message2: 'Sie können mit dem Kommentieren fortfahren:',
     message3: 'Bitte aktualisieren Sie diese Seite, wenn die Ruhezeit abgelaufen ist.'
-  }
+  },
+  goToTop: "Gehen Sie zurück nach oben"
 }

--- a/frontend/i18n/en/generic.js
+++ b/frontend/i18n/en/generic.js
@@ -24,5 +24,6 @@ export default {
     message1: 'Thank you for your work!',
     message2: 'You can continue annotating at:',
     message3: 'Please refresh this page when the time to rest has ended.'
-  }
+  },
+  goToTop: "Go back to the top"
 }

--- a/frontend/i18n/fr/generic.js
+++ b/frontend/i18n/fr/generic.js
@@ -23,5 +23,6 @@ export default {
     message1: 'Merci pour votre travail!',
     message2: 'Vous pouvez continuer à annoter à :',
     message3: 'Veuillez actualiser cette page lorsque le temps de repos est terminé.'
-  }
+  },
+  goToTop: "Revenir en haut"
 }

--- a/frontend/i18n/pl/generic.js
+++ b/frontend/i18n/pl/generic.js
@@ -24,5 +24,6 @@ export default {
     message1: 'Dziękujemy za Twoją pracę!',
     message2: 'Możesz kontynuować anotację od:',
     message3: 'Odśwież tę stronę, gdy czas na odpoczynek się skończy.'
-  }
+  },
+  goToTop: "Wróć na górę"
 }

--- a/frontend/i18n/zh/generic.js
+++ b/frontend/i18n/zh/generic.js
@@ -23,5 +23,6 @@ export default {
     message1: '感谢您的工作!',
     message2: '您可以在此日期继续注释:',
     message3: '请在休息时间结束后刷新此页面.'
-  }
+  },
+  goToTop: "返回顶部"
 }

--- a/frontend/layouts/questionnaire.vue
+++ b/frontend/layouts/questionnaire.vue
@@ -37,7 +37,14 @@ export default {
   computed: {
     ...mapGetters('user', ['getQuestionnaire']),
     toShowCategoryKey() {
-      return this.$route.path.split("/")[2]
+      const localeCodes = this.$i18n.locales.map((locale) => "/" + locale.code + "/")
+      let indexToSplit = 2
+      for (let i = 0; i < localeCodes.length; i++) {
+        if (this.$route.path.includes(localeCodes[i])) {
+          indexToSplit = 3
+        }
+      }
+      return this.$route.path.split("/")[indexToSplit]
     },
     qCategoryId() {
       return this.qCategories.find((qCategory)=> qCategory.key === this.toShowCategoryKey).id
@@ -56,7 +63,7 @@ export default {
     validateQuestionnaire() {
       const {toShow} = this.getQuestionnaire
       if(toShow[0] !== this.toShowId) {
-        this.$router.push("/questionnaires")
+        this.$router.push(this.localePath('/questionnaires'))
       }
     },
   }

--- a/frontend/middleware/check-questionnaire.js
+++ b/frontend/middleware/check-questionnaire.js
@@ -1,6 +1,6 @@
 import { qCategories } from "~/utils/questionnaires"
 
-export default function ({ store, route, redirect }) {
+export default function ({ store, route, redirect, app }) {
     const isStaff = store.getters['auth/isStaff']
     const {toShow} = store.getters['user/getQuestionnaire']
     const isOnQuestionnairePage = route.path.includes("/questionnaires")
@@ -12,12 +12,13 @@ export default function ({ store, route, redirect }) {
         const toShowCategoryId = toShowId.split(".")[0]
         const { key } = qCategories.find((qCategory)=> qCategory.id === toShowCategoryId )
         
+        const locale = app.i18n.locale ?? 'en'
         if(!isStaff && toShow.length && !isOnQuestionnairePage) {
-            return redirect("/questionnaires")
+            return redirect(locale + "/questionnaires")
         } 
         else if(!isStaff && toShow.length && isOnQuestionnairePage) {
             if(isWorkingNow && (isOnMainQuestionnairePage || !route.path.includes(key))) { 
-                redirect(`/questionnaires/${key}`)
+                redirect(`${locale}/questionnaires/${key}`)
             }
         }
     } else if(hasValidToShow && !toShow.length && isOnQuestionnairePage)  {

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -479,7 +479,7 @@ export default {
       deep: true,
       handler() {
         if(valtoShow.length) {
-          this.$router.push("/questionnaires")
+          this.$router.push(this.localePath('/questionnaires'))
         }
       }
     },

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -245,6 +245,9 @@
                   @update:label="updateTag"
                   @remove:label="removeTag"
                 />
+                <v-btn block color="primary" @click="scrollToTop">
+                  {{ $i18n.t('generic.goToTop') }}
+                </v-btn>
               </v-card>
             </v-col>
           </v-row>
@@ -977,6 +980,12 @@ export default {
         )
         await this.list(this.doc.id)
       }
+    },
+    scrollToTop() {
+      window.scrollTo({
+        top: 0,
+        behavior: "smooth"
+      })
     }
   }
 }

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -49,7 +49,7 @@ export default Vue.extend({
   },
   layout: 'projects',
 
-  middleware: ['check-auth', 'auth', 'check-questionnaire'],
+  middleware: ['check-auth', 'auth'],
 
   data() {
     return {
@@ -153,7 +153,7 @@ export default Vue.extend({
     checkQuestionnaire() {
       this.initQuestionnaire()
       if (!this.isStaff && this.getQuestionnaire.toShow.length) {
-        this.$router.push('/questionnaires')
+        this.$router.push(this.localePath('/questionnaires'))
       }
     },
 

--- a/frontend/pages/questionnaires/index.vue
+++ b/frontend/pages/questionnaires/index.vue
@@ -35,7 +35,7 @@ export default {
         const questionnaireId = toShow[0].split('.')[0]
         base.setQuestionnaire({ inProgress: [toShow[0]], isWorkingNow: true })
         const { key } = base.qCategories.find((k: any) => k.id === questionnaireId)
-        base.$router.push(`/questionnaires/${key}/`)
+        base.$router.push(base.localePath(`/questionnaires/${key}/`))
       }
     }
   }


### PR DESCRIPTION
What's changed:
 - frontend/layouts/questionnaire.vue : Add current locale to the router push, calculate the index to split based on whether current path contains locale code
 - frontend/components/questionnaires/QuestionnaireForm.vue : Add current locale to the router push
 - frontend/pages/questionnaires/index.vue : Add current locale to the router push
 - frontend/pages/projects/index.vue : Add current locale to the router push, remove middleware because it was causing a bug when called twice from this file and the questionnaires layout (`checkQuestionnaire()` already does the work anyway to redirect to questionnaires)
 - frontend/middleware/check-questionnaire.js : Add locale into redirect
 - frontend/pages/projects/_id/affective-annotation/index.vue : Add current locale to the router push, add button to scroll back to top
 - frontend/i18n/de/generic.js : Add translation for go back to top button
 - frontend/i18n/en/generic.js : Add translation for go back to top button
 - frontend/i18n/fr/generic.js : Add translation for go back to top button
 - frontend/i18n/pl/generic.js : Add translation for go back to top button
 - frontend/i18n/zh/generic.js : Add translation for go back to top button

Screenshots:
<img width="960" alt="ss2" src="https://user-images.githubusercontent.com/64476430/205514303-e8ee4d41-6cdc-4df3-89a3-4790d07650f1.PNG">
