### PR TITLE
feat: FE - SliderInput in radio, sticky text, state implementation

### DIFF
--- a/frontend/components/auth/FormLogin.vue
+++ b/frontend/components/auth/FormLogin.vue
@@ -307,12 +307,12 @@ export default Vue.extend({
                     questionnaireTypeId: 1,
                     limit: 1
                   })
-				  let firstQuestionnaireEverDate = null
-				  if (questionnaireStates) {
-					  const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
-					  firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+                  let firstQuestionnaireEverDate = null
+                  if (questionnaireStates && questionnaireStates.items.length > 0) {
+                    const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
+                    firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
                   }
-				  await this.initQuestionnaire(firstQuestionnaireEverDate)
+                  await this.initQuestionnaire(firstQuestionnaireEverDate)
                 })
                 this.$router.push(this.localePath('/projects'))
               }

--- a/frontend/components/auth/FormLogin.vue
+++ b/frontend/components/auth/FormLogin.vue
@@ -303,7 +303,16 @@ export default Vue.extend({
               if (this.isLoaded) {
                 await this.setUserData()
                 this.$nextTick(async () => {
-                  await this.initQuestionnaire()
+                  const questionnaireStates = await this.$services.questionnaire.listFinishedQuestionnaires({
+                    questionnaireTypeId: 1,
+                    limit: 1
+                  })
+				  let firstQuestionnaireEverDate = null
+				  if (questionnaireStates) {
+					  const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
+					  firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+                  }
+				  await this.initQuestionnaire(firstQuestionnaireEverDate)
                 })
                 this.$router.push(this.localePath('/projects'))
               }

--- a/frontend/components/auth/FormLogin.vue
+++ b/frontend/components/auth/FormLogin.vue
@@ -102,7 +102,8 @@ export default Vue.extend({
       this.questionnaires = _.cloneDeep(_.flatMap(questionnaireResponses, 'items'))
       this.questionnaireStates = _.cloneDeep(states.items)
 
-      const stateTypes = _.flatMap(this.questionnaireStates, 'questionnaire')
+      const stateTypes = [...new Set(_.flatMap(this.questionnaireStates, 'questionnaire'))]
+      console.log(stateTypes)
       const finishedCategories = _.flatMap(qCategories, 'types')
         .map((qType) => {
           qType.intersections = _.intersection(qType.questionnaires, stateTypes)
@@ -110,6 +111,7 @@ export default Vue.extend({
             qType.questionnaires.includes(state.questionnaire)
           )
           qType.finishedAt = state ? state.finishedAt : ''
+          qType.hasFinishedAll = qType.intersections.length === qType.questionnaires.length
 
           return qType
         })
@@ -119,9 +121,10 @@ export default Vue.extend({
           const finishedAt = qType.finishedAt
             ? moment(qType.finishedAt, 'YYYY-MM-DDThh:mm:ss').format('DD-MM-YYYY')
             : ''
+
           return qType.id.startsWith(dailyQuestionnaireId)
-            ? todayDay === finishedAt && isInside
-            : isInside
+            ? todayDay === finishedAt && isInside && qType.hasFinishedAll
+            : isInside && qType.hasFinishedAll
         })
 
       this.setQuestionnaire({

--- a/frontend/components/auth/FormLogin.vue
+++ b/frontend/components/auth/FormLogin.vue
@@ -163,9 +163,8 @@ export default Vue.extend({
             qType.hasFinishedToday = !!todayQStates.length
             qType.hasFinishedAllTypesToday = !!todayQStates.length && hasFinishedAllTypes
 
-            const monthDiff = moment(new Date()).diff(
-              moment(qType.finishedAt, dateFormat),
-              'months'
+            const monthDiff = Math.abs(
+              moment(new Date()).diff(moment(qType.finishedAt, dateFormat), 'months')
             )
             const hasPassedResearchTime = monthDiff >= researchTimeInMonths
 
@@ -178,9 +177,8 @@ export default Vue.extend({
               qType.hasFinishedAllTypes =
                 hasFinishedAllTypes && qType.filledTypes.length === qType.questionnaires.length * 2
             } else if (qType.id === '3.1') {
-              const weekDiff = moment(new Date()).diff(
-                moment(qType.finishedAt, savedDateFormat),
-                'weeks'
+              const weekDiff = Math.abs(
+                moment(new Date()).diff(moment(qType.finishedAt, savedDateFormat), 'weeks')
               )
               const hasPassedOneWeek = weekDiff >= 1
               qType.hasFinishedAllTypes = hasFinishedAllTypes && hasPassedOneWeek
@@ -208,9 +206,8 @@ export default Vue.extend({
             } else if (qType.id === '5.1') {
               qType.hasFinishedAllTypes = hasFinishedAllTypes && hasPassedResearchTime
             } else if (qType.id === '6.1') {
-              const weekDiff = moment(new Date()).diff(
-                moment(qType.finishedAt, dateFormat),
-                'weeks'
+              const weekDiff = Math.abs(
+                moment(new Date()).diff(moment(qType.finishedAt, dateFormat), 'weeks')
               )
               const hasPassedTwoWeeks = weekDiff >= 2
               qType.hasFinishedAllTypes = hasFinishedAllTypes && hasPassedTwoWeeks
@@ -247,7 +244,7 @@ export default Vue.extend({
         const lastLoginDay = parseInt(moment(lastLoginTime, dateFormat).format('DD'))
         const todayDay = parseInt(moment().format('DD'))
         let currentDiffDay = this.getLogin.lastLoginTime
-          ? moment(new Date()).diff(moment(lastLoginTime, dateFormat), 'days')
+          ? Math.abs(moment(new Date()).diff(moment(lastLoginTime, dateFormat), 'days'))
           : 0
         currentDiffDay = currentDiffDay === 0 ? todayDay - lastLoginDay : currentDiffDay
 

--- a/frontend/components/auth/FormLogin.vue
+++ b/frontend/components/auth/FormLogin.vue
@@ -133,13 +133,19 @@ export default Vue.extend({
             'finishedAt'
           ).reverse()
         }
-
-        const stateTypes: any[] = [...new Set(_.flatMap(this.questionnaireStates, 'questionnaire'))]
+        const stateTypes: any[] = _.flatMap(this.questionnaireStates, 'questionnaire')
+        const uniqueStateTypes: any[] = [
+          ...new Set(_.flatMap(this.questionnaireStates, 'questionnaire'))
+        ]
         const finishedQTypes: any[] = qTypes
           .map((qType) => {
-            qType.filledTypes = _.intersection(qType.questionnaires, stateTypes)
-            qType.filledTypesUnique = [...new Set(_.intersection(qType.questionnaires, stateTypes))]
-            qType.filledTypesOnlyDouble = qType.filledTypesUnique.every((fType) => {
+            qType.filledTypes = stateTypes.filter((stateType) =>
+              qType.questionnaires.includes(stateType)
+            )
+            qType.filledTypesUnique = [
+              ...new Set(_.intersection(qType.questionnaires, uniqueStateTypes))
+            ]
+            qType.filledTypesOnlyDouble = qType.filledTypesUnique.filter((fType) => {
               return qType.filledTypes.filter((fType2) => fType === fType2).length > 1
             })
             qType.filledTypesOnlyOnce = _.difference(
@@ -151,7 +157,8 @@ export default Vue.extend({
               _.flatMap(todayFilledQuestionnaires, 'questionnaire')
             )
 
-            const hasFinishedAllTypes = qType.filledTypes.length === qType.questionnaires.length
+            const hasFinishedAllTypes =
+              qType.filledTypesUnique.length === qType.questionnaires.length
 
             const qStates = this.questionnaireStates
               .filter((state) => qType.questionnaires.includes(state.questionnaire))
@@ -180,13 +187,16 @@ export default Vue.extend({
             } else if (qType.id === '2.1') {
               qType.hasFinishedAllTypes = hasFinishedAllTypes
             } else if (qType.id === '2.2') {
+              console.log(qType.filledTypesOnlyDouble)
               qType.hasFinishedAllTypes =
-                hasFinishedAllTypes && qType.filledTypes.length === qType.questionnaires.length * 2
+                hasFinishedAllTypes &&
+                qType.filledTypesOnlyDouble.length * 2 >= qType.questionnaires.length * 2
             } else if (qType.id === '3.1') {
               qType.hasFinishedAllTypes = hasFinishedAllTypes
             } else if (qType.id === '3.2') {
               qType.hasFinishedAllTypes =
-                hasFinishedAllTypes && qType.filledTypes.length === qType.questionnaires.length * 2
+                hasFinishedAllTypes &&
+                qType.filledTypesOnlyDouble.length * 2 >= qType.questionnaires.length * 2
             } else if (qType.id === '4.1') {
               qType.hasFinishedAllTypes = qType.hasFinishedAllTypesToday
             } else if (qType.id === '4.2') {

--- a/frontend/components/auth/FormLogin.vue
+++ b/frontend/components/auth/FormLogin.vue
@@ -156,9 +156,7 @@ export default Vue.extend({
               qType.questionnaires,
               _.flatMap(todayFilledQuestionnaires, 'questionnaire')
             )
-
-            const hasFinishedAllTypes =
-              qType.filledTypesUnique.length === qType.questionnaires.length
+            qType.filledId = [qType.id]
 
             const qStates = this.questionnaireStates
               .filter((state) => qType.questionnaires.includes(state.questionnaire))
@@ -178,24 +176,18 @@ export default Vue.extend({
             }
 
             qType.hasFinishedToday = !!todayQStates.length
+            qType.hasFinishedAllTypes =
+              qType.filledTypesUnique.length === qType.questionnaires.length
             qType.hasFinishedAllTypesToday =
               !!todayQStates.length && qType.filledTypesToday.length >= qType.questionnaires.length
 
-            qType.filledId = [qType.id]
-            if (qType.id === '1.1') {
-              qType.hasFinishedAllTypes = hasFinishedAllTypes
-            } else if (qType.id === '2.1') {
-              qType.hasFinishedAllTypes = hasFinishedAllTypes
-            } else if (qType.id === '2.2') {
-              console.log(qType.filledTypesOnlyDouble)
+            if (qType.id === '2.2') {
               qType.hasFinishedAllTypes =
-                hasFinishedAllTypes &&
+                qType.hasFinishedAllTypes &&
                 qType.filledTypesOnlyDouble.length * 2 >= qType.questionnaires.length * 2
-            } else if (qType.id === '3.1') {
-              qType.hasFinishedAllTypes = hasFinishedAllTypes
             } else if (qType.id === '3.2') {
               qType.hasFinishedAllTypes =
-                hasFinishedAllTypes &&
+                qType.hasFinishedAllTypes &&
                 qType.filledTypesOnlyDouble.length * 2 >= qType.questionnaires.length * 2
             } else if (qType.id === '4.1') {
               qType.hasFinishedAllTypes = qType.hasFinishedAllTypesToday
@@ -206,10 +198,6 @@ export default Vue.extend({
                 ? _.flatMap(todayAtRestQuestionnairesIds, 'restId')
                 : [qType.id]
               qType.hasFinishedAllTypes = qType.hasFinishedAllTypesToday
-            } else if (qType.id === '5.1') {
-              qType.hasFinishedAllTypes = hasFinishedAllTypes
-            } else if (qType.id === '6.1') {
-              qType.hasFinishedAllTypes = hasFinishedAllTypes
             }
 
             return qType

--- a/frontend/components/auth/FormLogin.vue
+++ b/frontend/components/auth/FormLogin.vue
@@ -95,7 +95,7 @@ export default Vue.extend({
         const serverDateFormat = 'YYYY-MM-DDThh:mm:ss'
         const dateFormat = 'DD-MM-YYYY'
         const savedDateFormat = 'DD-MM-YYYY hh:mm:ss'
-        let todayAtRestQuestionnairesIds = []
+        let todayAtRestQuestionnairesIds: any[] = []
         const todayDate = moment().format(dateFormat)
         const qTypes = _.flatMap(qCategories, 'types')
         const { hasAnnotatedToday } = this.getAnnotation
@@ -111,7 +111,7 @@ export default Vue.extend({
 
         const questionnaireResponses: any[] = await Promise.all(questionnairePromises)
         this.questionnaires = _.cloneDeep(_.flatMap(questionnaireResponses, 'items'))
-        const questionnaireStates = _.sortBy(states.items, 'finishedAt').map((state) => {
+        const questionnaireStates: any[] = _.sortBy(states.items, 'finishedAt').map((state) => {
           state.finishedAtDate = state.finishedAt
             ? moment(state.finishedAt, serverDateFormat).format(dateFormat)
             : ''
@@ -169,7 +169,7 @@ export default Vue.extend({
             )
             const hasPassedResearchTime = monthDiff >= researchTimeInMonths
 
-            qType.filledId = qType.id
+            qType.filledId = [qType.id]
             if (qType.id === '1.1') {
               qType.hasFinishedAllTypes = hasFinishedAllTypes
             } else if (qType.id === '2.1') {
@@ -199,8 +199,9 @@ export default Vue.extend({
               const firstTodayAtRestQuestionnaire = todayAtRestQuestionnairesIds.length
                 ? todayAtRestQuestionnairesIds[0]
                 : {}
-              console.log(firstTodayAtRestQuestionnaire)
-              qType.filledId = firstTodayAtRestQuestionnaire.restId
+              qType.filledId = todayAtRestQuestionnairesIds.length
+                ? _.flatMap(todayAtRestQuestionnairesIds, 'restId')
+                : [qType.id]
               qType.hasFinishedAllTypes =
                 hasFinishedAllTypes && firstTodayAtRestQuestionnaire.finishedAtDate
               todayAtRestQuestionnairesIds.splice(0, 1)
@@ -222,7 +223,7 @@ export default Vue.extend({
           })
 
         await this.setQuestionnaire({
-          filled: _.flatMap(finishedCategories, 'filledId'),
+          filled: [..._.flatMap(finishedCategories, 'filledId')],
           toShow: []
         })
         this.isLoaded = true

--- a/frontend/components/auth/FormLogin.vue
+++ b/frontend/components/auth/FormLogin.vue
@@ -310,7 +310,7 @@ export default Vue.extend({
                   let firstQuestionnaireEverDate = null
                   if (questionnaireStates && questionnaireStates.items.length > 0) {
                     const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
-                    firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+                    firstQuestionnaireEverDate = moment(String(firstQuestionnaireEver)).format('DD-MM-YYYY')
                   }
                   await this.initQuestionnaire(firstQuestionnaireEverDate)
                 })

--- a/frontend/components/auth/FormLogin.vue
+++ b/frontend/components/auth/FormLogin.vue
@@ -117,7 +117,7 @@ export default Vue.extend({
           return qType
         })
         .filter((qType) => {
-          const hasFilledSome = qType.intersections.length > 0
+          const hasFilledSome = qType.filledTypes.length > 0
           const todayDay = moment().format('DD-MM-YYYY')
           const finishedAt = qType.finishedAt
             ? moment(qType.finishedAt, 'YYYY-MM-DDThh:mm:ss').format('DD-MM-YYYY')

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -338,6 +338,7 @@ export default {
         )
         if (hasClickedEverything) {
           this.createQuestionnaireFinishedState()
+
           this.showWarning = false
           this.activeQuestionnaire += 1
           window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -408,5 +409,11 @@ export default {
 }
 
 .sticky {
+  position: fixed;
+  top: 90px;
+  min-width: 250px;
+  max-width: 270px;
+  overflow-x: visible;
+  z-index: 1;
 }
 </style>

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -338,7 +338,6 @@ export default {
         )
         if (hasClickedEverything) {
           this.createQuestionnaireFinishedState()
-
           this.showWarning = false
           this.activeQuestionnaire += 1
           window.scrollTo({ top: 0, behavior: 'smooth' })

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -368,7 +368,7 @@ export default {
     goToNextQuestionnaire() {
       const { toShow } = this.getQuestionnaire
       if (toShow.length) {
-        const toShowId = toShow[1].split('.')[0]
+        const toShowId = toShow[0].split('.')[0]
         const { key } = qCategories.find((qc) => String(qc.id) === toShowId)
         this.$router.push(this.localePath(`/questionnaires/${key}`))
       } else {

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -337,10 +337,10 @@ export default {
           question.required && question.isValid ? question.isClicked : true
         )
         if (hasClickedEverything) {
+          this.createQuestionnaireFinishedState()
           this.showWarning = false
           this.activeQuestionnaire += 1
           window.scrollTo({ top: 0, behavior: 'smooth' })
-          this.createQuestionnaireFinishedState()
         } else {
           this.scrollToFaultyQuestion(this.activeQuestionnaire, questions)
         }

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -115,7 +115,7 @@
                   </v-card>
                 </v-col>
                 <v-col cols="4" class="sticky-container">
-                  <v-card v-if="questionnaire.segments[0].scales" class="sticky">
+                  <v-card v-if="questionnaire.segments[0].scales" :class="(showWarning) ? 'sticky-offset' : 'sticky'">
                     <v-card-text>
                       <div class="segment-description-container text-caption">
                         <ul class="hide-list-style">
@@ -420,6 +420,15 @@ export default {
 .sticky {
   position: fixed;
   top: 90px;
+  min-width: 250px;
+  max-width: 270px;
+  overflow-x: visible;
+  z-index: 1;
+}
+
+.sticky-offset {
+  position: fixed;
+  top: 200px;
   min-width: 250px;
   max-width: 270px;
   overflow-x: visible;

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -1,18 +1,15 @@
 <template>
-  <v-row align="center" justify="center" >
+  <v-row align="center" justify="center">
     <v-col cols="9">
       <div ref="header">
-        <v-alert
-            v-model="showWarning"
-            color="error"
-            dark
-            transition="scale-transition"
-            dismissible
-            >
-        {{ $t('errors.incompleteAffectiveAnnotation') }}
+        <v-alert v-model="showWarning" color="error" dark transition="scale-transition" dismissible>
+          {{ $t('errors.incompleteAffectiveAnnotation') }}
         </v-alert>
       </div>
-      <div v-if="formData.questionnaires && formData.questionnaires.length && isLoaded" class="questionnaire-container">
+      <div
+        v-if="formData.questionnaires && formData.questionnaires.length && isLoaded"
+        class="questionnaire-container"
+      >
         <v-col>
           <v-window
             v-model="activeQuestionnaire"
@@ -23,14 +20,11 @@
               v-for="(questionnaire, qIdx) in formData.questionnaires"
               :key="`questionnaire-window-${qIdx}`"
             >
-              <v-row align="top" justify="center" >
+              <v-row align="top" justify="center">
                 <v-col cols="8">
                   <v-card>
                     <v-card-text>
-                      <v-row
-                        class="mb-4"
-                        align="center"
-                      >
+                      <v-row class="mb-4" align="center">
                         <v-col>
                           <p class="text-caption">
                             {{ questionnaire.description }}
@@ -41,50 +35,62 @@
                               :key="`segment-${segIdx}`"
                               class="hide-list-style"
                             >
-                              <div v-if="segment.scales" class="segment-description-container text-caption">
-                                <p >
+                              <div
+                                v-if="segment.scales"
+                                class="segment-description-container text-caption"
+                              >
+                                <p>
                                   {{ segment.scales.description }}
                                 </p>
                               </div>
 
                               <div v-if="segment.questions">
-                                <ol :class="segment.prependIndex ? 'segment-question hide-list-style' : 'segment-question'">
-                                    <li 
-                                      v-for="(segmentQuestion, segQuIdx) in segment.questions" 
-                                      :ref="`question_${qIdx}_${segQuIdx}`"
-                                      :key="`segmentQuestion-${segQuIdx}`"
-                                    >
-                                      <div v-if="segmentQuestion.id" class="question-container">
-                                        <span v-if="segment.prependIndex">
-                                          {{ segment.prependIndex+(segQuIdx+1) }}
-                                        </span>
-                                        <component 
-                                          :is="getComponent(segmentQuestion.type)"
-                                          v-model="segmentQuestion.value"
-                                          :header="segmentQuestion.header"
-                                          :required="segmentQuestion.required"
-                                          :question="segmentQuestion.text"
-                                          :options="segmentQuestion.options"
-                                          :config="segmentQuestion.config"
-                                          :is-clicked="segmentQuestion.isClicked"
-                                          :is-submitting="segmentQuestion.isSubmitting"
-                                          :error-message="segmentQuestion.errorMessage"
-                                          :read-only="segmentQuestion.readOnly"
-                                          :passed-data="{
-                                              question: segmentQuestion, 
-                                              formDataKey: getFormDataKey(segQuIdx, segIdx, qIdx)
-                                            }"
-                                          @change="onQuestionChange"
-                                        />
-                                      </div>
-                                      <p v-else>
-                                        {{ $t('questionnaires_main.errorDataMapping') }}
-                                      </p>
-                                    </li>
+                                <ol
+                                  :class="
+                                    segment.prependIndex
+                                      ? 'segment-question hide-list-style'
+                                      : 'segment-question'
+                                  "
+                                >
+                                  <li
+                                    v-for="(segmentQuestion, segQuIdx) in segment.questions"
+                                    :ref="`question_${qIdx}_${segQuIdx}`"
+                                    :key="`segmentQuestion-${segQuIdx}`"
+                                  >
+                                    <div v-if="segmentQuestion.id" class="question-container">
+                                      <span v-if="segment.prependIndex">
+                                        {{ segment.prependIndex + (segQuIdx + 1) }}
+                                      </span>
+                                      <component
+                                        :is="getComponent(segmentQuestion.type)"
+                                        v-model="segmentQuestion.value"
+                                        :header="segmentQuestion.header"
+                                        :required="segmentQuestion.required"
+                                        :question="segmentQuestion.text"
+                                        :options="segmentQuestion.options"
+                                        :config="segmentQuestion.config"
+                                        :is-clicked="segmentQuestion.isClicked"
+                                        :is-submitting="segmentQuestion.isSubmitting"
+                                        :error-message="segmentQuestion.errorMessage"
+                                        :read-only="segmentQuestion.readOnly"
+                                        :passed-data="{
+                                          question: segmentQuestion,
+                                          formDataKey: getFormDataKey(segQuIdx, segIdx, qIdx)
+                                        }"
+                                        @change="onQuestionChange"
+                                      />
+                                    </div>
+                                    <p v-else>
+                                      {{ $t('questionnaires_main.errorDataMapping') }}
+                                    </p>
+                                  </li>
                                 </ol>
                               </div>
-                              
-                              <v-divider v-if="segIdx < questionnaire.segments.length-1" class="mt-10 mb-10" />
+
+                              <v-divider
+                                v-if="segIdx < questionnaire.segments.length - 1"
+                                class="mt-10 mb-10"
+                              />
                             </li>
                           </ul>
                           <!-- eslint-disable-next-line vue/no-v-html -->
@@ -95,8 +101,11 @@
                     <v-divider />
                     <v-card-actions>
                       <v-spacer />
-                      <v-btn v-if="activeQuestionnaire+1 < formData.questionnaires.length" 
-                        color="primary" @click="onClickContinueButton">
+                      <v-btn
+                        v-if="activeQuestionnaire + 1 < formData.questionnaires.length"
+                        color="primary"
+                        @click="onClickContinueButton"
+                      >
                         {{ $t('questionnaires_main.buttonFinish') }}
                       </v-btn>
                       <v-btn v-else color="primary" @click="onClickFinishButton">
@@ -110,9 +119,11 @@
                     <v-card-text>
                       <div class="segment-description-container text-caption">
                         <ul class="hide-list-style">
-                          <li 
-                            v-for="(segmentScaleValue, segScalIdx) in questionnaire.segments[0].scales.values" 
-                            :key="`segmentScaleValue-${segScalIdx}`">
+                          <li
+                            v-for="(segmentScaleValue, segScalIdx) in questionnaire.segments[0]
+                              .scales.values"
+                            :key="`segmentScaleValue-${segScalIdx}`"
+                          >
                             {{ segmentScaleValue.value }} - {{ segmentScaleValue.text }}
                           </li>
                         </ul>
@@ -125,14 +136,17 @@
           </v-window>
         </v-col>
       </div>
-      <div v-else-if="formData.questionnaires && !formData.questionnaires.length && isLoaded" class="align-right">
+      <div
+        v-else-if="formData.questionnaires && !formData.questionnaires.length && isLoaded"
+        class="align-right"
+      >
         <v-card>
           <v-card-text>
-          {{ $t('questionnaires_main.errorNotFound') }}
+            {{ $t('questionnaires_main.errorNotFound') }}
           </v-card-text>
-          <v-divider/>
+          <v-divider />
           <v-card-actions>
-            <v-spacer/>
+            <v-spacer />
             <v-btn color="primary" @click="onClickFinishButton">
               {{ $t('questionnaires_main.buttonFinish') }}
             </v-btn>
@@ -140,10 +154,7 @@
         </v-card>
       </div>
       <div v-else-if="!isLoaded">
-        <v-progress-circular
-          indeterminate
-          color="primary"
-        ></v-progress-circular>
+        <v-progress-circular indeterminate color="primary"></v-progress-circular>
       </div>
     </v-col>
   </v-row>
@@ -179,6 +190,7 @@ export default {
       mappedQTypes: [],
       questionnaires: [],
       questions: [],
+      questionnaireStates: [],
       activeQuestionnaire: 0,
       isLoaded: false,
       showWarning: false,
@@ -207,7 +219,19 @@ export default {
     setFormData() {
       const selectedQType = this.mappedQTypes.find((qType) => qType.id === this.toShowId)
       const formData = selectedQType ? _.cloneDeep(selectedQType) : { questionnaires: [] }
-      this.formData = setQuestionnaireIds([formData], this.questionnaires, this.questions)[0]
+      this.formData = setQuestionnaireIds(
+        [formData],
+        this.questionnaires,
+        this.questions,
+        this.questionnaireStates
+      )[0]
+      const toFillQuestionnaireId = this.formData.questionnaires.findIndex((q) => !q.isFinished)
+      if (~toFillQuestionnaireId) {
+        this.activeQuestionnaire = toFillQuestionnaireId
+      } else {
+        this.setQuestionnaireHistory()
+        this.$router.push(this.localePath('/questionnaires'))
+      }
     },
     initialize() {
       this.showWarning = false
@@ -229,11 +253,16 @@ export default {
           limit
         })
       })
+      const questionnaireStates = await this.$services.questionnaire.listFinishedQuestionnaires({
+        questionnaireTypeId: typeId,
+        limit
+      })
       const responses = await Promise.all(promises)
       const questions = _.flatMap(responses, 'items')
 
       this.questionnaires = _.cloneDeep(questionnaires.items)
       this.questions = _.cloneDeep(questions)
+      this.questionnaireStates = _.cloneDeep(questionnaireStates.items)
     },
     getFormDataKey(segQuIdx, segIdx, qIdx) {
       return `questionnaires[${qIdx}].segments[${segIdx}].questions[${segQuIdx}]`
@@ -296,6 +325,10 @@ export default {
         this.$refs.header.scrollIntoView({ behavior: 'smooth' })
       }
     },
+    async createQuestionnaireFinishedState() {
+      const selectedQuestionnaire = this.formData.questionnaires[this.activeQuestionnaire]
+      await this.$services.questionnaire.createQuestionnaireFinishedState(selectedQuestionnaire.id)
+    },
     onClickContinueButton() {
       const selectedQuestionnaire = this.formData.questionnaires[this.activeQuestionnaire]
       if (selectedQuestionnaire) {
@@ -307,12 +340,13 @@ export default {
           this.showWarning = false
           this.activeQuestionnaire += 1
           window.scrollTo({ top: 0, behavior: 'smooth' })
+          this.createQuestionnaireFinishedState()
         } else {
           this.scrollToFaultyQuestion(this.activeQuestionnaire, questions)
         }
       }
     },
-    resetQuestionnaire() {
+    setQuestionnaireHistory() {
       const { toShow, filled } = this.getQuestionnaire
       const { textCountToday } = this.getAnnotation
       const specialCombinations = [['4.3', textCountToday]]
@@ -337,13 +371,14 @@ export default {
           question.required && question.isValid ? question.isClicked : true
         )
         if (hasClickedEverything) {
-          this.resetQuestionnaire()
+          this.createQuestionnaireFinishedState()
+          this.setQuestionnaireHistory()
           this.$router.push(this.localePath('/questionnaires'))
         } else {
           this.scrollToFaultyQuestion(questions)
         }
       } else {
-        this.resetQuestionnaire()
+        this.setQuestionnaireHistory()
         this.$router.push(this.localePath('/questionnaires'))
       }
     }

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -408,11 +408,5 @@ export default {
 }
 
 .sticky {
-  position: fixed;
-  top: 90px;
-  min-width: 250px;
-  max-width: 270px;
-  overflow-x: visible;
-  z-index: 1;
 }
 </style>

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -238,9 +238,10 @@ export default {
     getFormDataKey(segQuIdx, segIdx, qIdx) {
       return `questionnaires[${qIdx}].segments[${segIdx}].questions[${segQuIdx}]`
     },
-    async onQuestionChange({ question, formDataKey, hasFilledEverything }) {
+    async onQuestionChange({ question, formDataKey, hasFilledEverything, isClicked }) {
       if (question && formDataKey) {
-        const isClicked = hasFilledEverything === undefined ? true : hasFilledEverything
+        hasFilledEverything = hasFilledEverything ?? true
+        isClicked = isClicked ?? hasFilledEverything
         const hasValue =
           typeof question.value !== 'undefined' && question.value !== null && question.value !== ''
         const { key } = question

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -336,6 +336,8 @@ export default {
         const hasClickedEverything = questions.every((question) =>
           question.required && question.isValid ? question.isClicked : true
         )
+        this.goToNextQuestionnaire()
+
         if (hasClickedEverything) {
           this.createQuestionnaireFinishedState()
           this.showWarning = false
@@ -363,6 +365,16 @@ export default {
         isWorkingNow: false
       })
     },
+    goToNextQuestionnaire() {
+      const { toShow } = this.getQuestionnaire
+      if (toShow.length) {
+        const toShowId = toShow[1].split('.')[0]
+        const { key } = qCategories.find((qc) => String(qc.id) === toShowId)
+        this.$router.push(this.localePath(`/questionnaires/${key}`))
+      } else {
+        this.$router.push(this.localePath('/projects'))
+      }
+    },
     onClickFinishButton() {
       const selectedQuestionnaire = this.formData.questionnaires[this.activeQuestionnaire]
       if (selectedQuestionnaire) {
@@ -370,10 +382,11 @@ export default {
         const hasClickedEverything = questions.every((question) =>
           question.required && question.isValid ? question.isClicked : true
         )
+        this.goToNextQuestionnaire()
         if (hasClickedEverything) {
           this.createQuestionnaireFinishedState()
           this.setQuestionnaireHistory()
-          this.$router.push(this.localePath('/questionnaires'))
+          this.goToNextQuestionnaire()
         } else {
           this.scrollToFaultyQuestion(questions)
         }

--- a/frontend/components/questionnaires/QuestionnaireForm.vue
+++ b/frontend/components/questionnaires/QuestionnaireForm.vue
@@ -336,8 +336,6 @@ export default {
         const hasClickedEverything = questions.every((question) =>
           question.required && question.isValid ? question.isClicked : true
         )
-        this.goToNextQuestionnaire()
-
         if (hasClickedEverything) {
           this.createQuestionnaireFinishedState()
           this.showWarning = false
@@ -382,7 +380,6 @@ export default {
         const hasClickedEverything = questions.every((question) =>
           question.required && question.isValid ? question.isClicked : true
         )
-        this.goToNextQuestionnaire()
         if (hasClickedEverything) {
           this.createQuestionnaireFinishedState()
           this.setQuestionnaireHistory()

--- a/frontend/components/questionnaires/form/DynamicSelectInput.vue
+++ b/frontend/components/questionnaires/form/DynamicSelectInput.vue
@@ -73,7 +73,7 @@ export default Vue.extend({
           }) && values.filter((val) => !!val).length
         : true
       this.$emit('input', values)
-      this.$emit('change', { ...this.passedData, hasFilledEverything, value: values })
+      this.$emit('change', { ...this.passedData, hasFilledEverything })
     },
     setFormData() {
       const option = this.options[0]

--- a/frontend/components/questionnaires/form/ScaleInput.vue
+++ b/frontend/components/questionnaires/form/ScaleInput.vue
@@ -5,7 +5,7 @@
     </small>
     <p>
       {{ question }}
-      <span v-if="required" class="red--text">*</span>
+      <span v-if="required && question" class="red--text">*</span>
     </p>
     <v-radio-group v-model="input">
       <v-radio
@@ -65,7 +65,7 @@ export default Vue.extend({
       set(val) {
         const base: any = this
         base.$emit('input', val)
-        base.$emit('change', { ...base.passedData, value: val })
+        base.$emit('change', { ...base.passedData })
       }
     }
   }

--- a/frontend/components/questionnaires/form/SelectInput.vue
+++ b/frontend/components/questionnaires/form/SelectInput.vue
@@ -3,7 +3,7 @@
     <p>
       {{ header }}
       {{ question }}
-      <span v-if="required" class="red--text">*</span>
+      <span v-if="required && question" class="red--text">*</span>
     </p>
     {{ input }}
     <v-select
@@ -118,7 +118,7 @@ export default Vue.extend({
       const key = '_single-value_'
       const value = this.inputText ? `${this.input}${key}${this.inputText}` : this.input
       this.$emit('input', value)
-      this.$emit('change', { ...this.passedData, value })
+      this.$emit('change', { ...this.passedData })
     }
   }
 })

--- a/frontend/components/questionnaires/form/SliderInput.vue
+++ b/frontend/components/questionnaires/form/SliderInput.vue
@@ -4,8 +4,8 @@
       {{ question }}
     </span>
     <span v-if="required && question" class="red--text">*</span>
-    <v-row align="center">
-      <v-col cols="12">
+    <v-row align="start" justify="center">
+      <v-col cols="12" align="start">
         <v-slider
           v-model="sliderValue"
           class="slider"

--- a/frontend/components/questionnaires/form/SliderInput.vue
+++ b/frontend/components/questionnaires/form/SliderInput.vue
@@ -3,9 +3,9 @@
     <span>
       {{ question }}
     </span>
-    <span v-if="required" class="red--text">*</span>
+    <span v-if="required && question" class="red--text">*</span>
     <v-row align="center">
-      <v-col>
+      <v-col cols="12">
         <v-slider
           v-model="sliderValue"
           class="slider"
@@ -55,7 +55,7 @@ export default Vue.extend({
       default: ''
     },
     value: {
-      type: Number,
+      type: [String, Number],
       default: -1
     },
     passedData: {
@@ -90,26 +90,35 @@ export default Vue.extend({
         .map((_, idx) => (start + idx).toString())
     }
   },
+  created() {
+    // @ts-ignore
+    this.parseValue()
+  },
   mounted() {
     // @ts-ignore
     this.isLoaded = true
   },
   methods: {
+    parseValue() {
+      const base: any = this
+      const pattern = /^[0-9]+$/
+      const isNumber = pattern.test(base.value)
+      base.sliderValue = isNumber ? base.value : base.config.min
+    },
     onSliderValueChange(val: any) {
       const base: any = this
       if (base.isLoaded) {
         base.$emit('input', val)
-        base.$emit('change', { ...base.passedData, value: val })
+        base.$emit('change', { ...base.passedData })
       }
     }
   }
 })
 </script>
 <style lang="scss">
-.v-input__prepend-outer {
-  width: 150px !important;
-}
-.v-input__append-outer {
-  width: 300px !important;
+.slider-input {
+  .v-slider__tick-label {
+    font-size: 0.875rem;
+  }
 }
 </style>

--- a/frontend/components/questionnaires/form/TextInput.vue
+++ b/frontend/components/questionnaires/form/TextInput.vue
@@ -1,9 +1,13 @@
 <template>
   <v-container class="widget">
     <v-row v-if="question" class="widget__question" align="center">
-      {{ header }}
-      {{ question }}
-      <span v-if="required" class="red--text"> * </span>
+      <v-col cols="12">
+        <span>
+          {{ header }}
+          {{ question }}
+          <span v-if="required" class="red--text"> * </span>
+        </span>
+      </v-col>
     </v-row>
     <v-row class="widget__answer" justify="center" align="center">
       <v-col :cols="12" class="widget__textfield" @click="textfieldClickHandler">
@@ -30,7 +34,7 @@
         </v-card-title>
         <v-card-text class="widget-dialog__text">
           <p class="widget-dialog__warning">{{ dialogErrorMessage }}</p>
-          <v-row justify="center" align="center">
+          <v-row justify="center" align="start">
             <v-col cols="10">
               <v-text-field
                 v-model.trim="text"
@@ -49,7 +53,7 @@
                 color="primary"
                 height="55px"
                 class="ma-0"
-                :disabled="!value"
+                :disabled="!text"
                 @click="submitAnswer"
               >
                 <v-icon>{{ mdiSend }}</v-icon>
@@ -216,6 +220,7 @@ export default {
   }
 
   &__textfield {
+    padding: 12px 0;
     .v-input {
       font-size: 0.8rem;
     }

--- a/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldModal.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldModal.vue
@@ -12,7 +12,7 @@
           dense
           outlined
           readonly
-          :value="showDialog ? '' : value"
+          :value="showDialog || text === emptyTextFlag ? '' : text"
           :rules="rulesTextfield"
           hide-details="auto"
         />
@@ -41,7 +41,7 @@
                 color="primary"
                 height="55px"
                 class="ma-0"
-                :disabled="!value"
+                :disabled="!text"
                 @click="submitAnswer"
               >
                 <v-icon>{{ mdiSend }}</v-icon>
@@ -92,6 +92,7 @@ export default {
   data() {
     return {
       mdiSend,
+      emptyTextFlag: '-',
       enableTextfield: true,
       showDialog: false,
       dialogErrorMessage: ''
@@ -101,7 +102,7 @@ export default {
   computed: {
     text: {
       get() {
-        return this.value
+        return this.value === this.emptyTextFlag ? '' : this.value
       },
       set(val) {
         this.$emit('input', val)

--- a/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
@@ -317,7 +317,7 @@ export default Vue.extend({
         })
         const hasFilledCheckedTextboxes = val.subquestion3.every((substatement: any) => {
           const hasCheckedAndFilled = substatement.isChecked
-            ? substatement.isChecked && !!substatement.answer
+            ? substatement.isChecked && !!substatement.answer && substatement.answer !== '-'
             : true
           return hasCheckedAndFilled
         })

--- a/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
@@ -91,7 +91,7 @@
                                         @change="onLabelChange(substatement, `subquestion3`, idx)" />
 
                                     <textfield-modal
-                                        v-if="substatement.isChecked"
+                                        v-if="substatement.isChecked && substatement.showTextbox"
                                         v-model="substatement.answer"
                                         :required="true"
                                         :readonly="readOnly"
@@ -127,6 +127,21 @@
                                             class="subquestions-item__checkbox"
                                             @change="onLabelChange(substatement, `subquestion4`, idx)"
                                         />
+
+                                    <textfield-modal
+                                        v-if="substatement.showTextbox && substatement.isChecked"
+                                        v-model="substatement.answer"
+                                        :required="true"
+                                        :readonly="readOnly"
+                                        :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
+                                        :question="$t(`annotation.offensive.subquestion4.substatement${(idx+1)}Question`)"
+                                        :full-question="`
+                                            ${$t(`annotation.offensive.subquestion4.substatement${(idx+1)}Question`)}
+                                             (${$t(`annotation.offensive.subquestion4.substatement${(idx+1)}`)})`"
+                                        :rules="[rules.required]"
+                                        class="subquestions-item__textfield"
+                                        @submit="onLabelChange(substatement, `subquestion4`, idx)"
+                                    />
                                     </p>
                                     </li>
                             </ul>
@@ -152,376 +167,388 @@ export default Vue.extend({
   },
   props: {
     project: {
-        type: Object,
-        default: () => {}
+      type: Object,
+      default: () => {}
     },
     value: {
-        type: Boolean,
-        default: false
+      type: Boolean,
+      default: false
     },
     doc: {
-        type: Object,
-        default: () => {}
+      type: Object,
+      default: () => {}
     },
     readOnly: {
-        type: Boolean,
-        default: false
+      type: Boolean,
+      default: false
     },
     showErrors: {
-        type: Boolean,
-        default: false
+      type: Boolean,
+      default: false
     },
     showBorders: {
-        type: Boolean,
-        default: false
+      type: Boolean,
+      default: false
     },
     scales: {
-        type: Array,
-        default: () => []
+      type: Array,
+      default: () => []
     },
     scaleTypes: {
-        type: Array,
-        default: () => []
+      type: Array,
+      default: () => []
     },
     textLabels: {
-        type: Array,
-        default: () => []
+      type: Array,
+      default: () => []
     }
   },
-    data() {
-        return {
-            polishAnnotation,
-            isLoaded: false,
-            rules: {
-                required: (value : any) => !!value || this.$i18n.t('rules.required'),
-            },
-            formData: {
-                subquestion1: {
-                    value: 0,
-                    isClicked: false,
-                    isSubmitting: false,
-                },
-                subquestion2: {
-                    value: 0,
-                    isClicked: false,
-                    isSubmitting: false,
-                },
-                subquestion3: [],
-                subquestion4: []
-            },
-            originalFormData: {
-                subquestion1: {
-                    value: 0,
-                    isClicked: false,
-                    isSubmitting: false,
-                },
-                subquestion2: {
-                    value: 0,
-                    isClicked: false,
-                    isSubmitting: false,
-                },
-                subquestion3: [],
-                subquestion4: []
-            }
-        }
-    },
-    computed: {
-        hasProperScaleTypes() : boolean {
-            const scaleLabels = [this.polishAnnotation.offensive.subquestion1, this.polishAnnotation.offensive.subquestion2]
-            const scaleTypeTexts = _.flatMap(this.scaleTypes, 'text')
-            return _.intersectionBy(scaleLabels, scaleTypeTexts).length > 0
+  data() {
+    return {
+      polishAnnotation,
+      isLoaded: false,
+      rules: {
+        required: (value: any) => !!value || this.$i18n.t('rules.required')
+      },
+      formData: {
+        subquestion1: {
+          value: 0,
+          isClicked: false,
+          isSubmitting: false
         },
-        scaleValues() : any[] {
-            return this.scales.map((scale: any) => {
-                const scaleType : any = this.scaleTypes.find((scaleType: any) => scaleType.id === scale.label) || {}
-                return {
-                    ...scale,
-                    ...scaleType,
-                    scaleTypeId: scale.label
-                }
-            })
+        subquestion2: {
+          value: 0,
+          isClicked: false,
+          isSubmitting: false
         },
-        textLabelValues() : any[] {
-            return this.textLabels.map((textLabel: any) => {
-                const substatementQuestion = textLabel.question
-                const annotation = _.cloneDeep(this.polishAnnotation.offensive) as any
-                let substatementKey = ''
-                Object.keys(annotation).forEach((subKey: string) => {
-                    if(typeof annotation[subKey] === 'object') {
-                        Object.keys(annotation[subKey]).every((subKey2: string) => {
-                            let isKey = annotation[subKey][subKey2] === textLabel.question
-                            if(textLabel.question.includes(" - ")) {
-                                const questions = textLabel.question.split(" - ")
-                                isKey =
-                                    annotation[subKey].question === questions[0]
-                                    && annotation[subKey][subKey2] === questions[1]
-                            }
-                            if(isKey) {
-                                substatementKey = `${subKey}.${subKey2}`
-                            }
-                            return !isKey
-                        })
-                    }
-                })
-                return {
-                    ...textLabel,
-                    substatementQuestion,
-                    substatementKey
-                }
-            })
+        subquestion3: [],
+        subquestion4: []
+      },
+      originalFormData: {
+        subquestion1: {
+          value: 0,
+          isClicked: false,
+          isSubmitting: false
         },
-        zeroToTenLabels() : number[] {
-            return Array.from(Array(11).keys())
+        subquestion2: {
+          value: 0,
+          isClicked: false,
+          isSubmitting: false
         },
-        hasFilledTopQuestions() : boolean {
-            return !!this.formData.subquestion1.value || 
-                !!this.formData.subquestion2.value; 
-        },
-    },
-    watch: {
-        doc() {
-            this.formData = _.cloneDeep(this.originalFormData)
-            this.$forceUpdate()
-        },
-        formData: {
-            deep: true,
-            handler(val: any) {
-                const scaleKeys = ['subquestion1', 'subquestion2']
-                const labelKeys = ['subquestion3', 'subquestion4']
-                const hasFilledScales = scaleKeys.some((scaleKey)=> {
-                    return val[scaleKey].isClicked
-                })
-                const hasFilledAllScalesZeros = scaleKeys.every((scaleKey)=> {
-                    return val[scaleKey].value === 0
-                })
-                const hasFilledAtLeastOneTextbox = labelKeys.some((labelKey)=> {
-                    return val[labelKey].some((formData: any )=> formData.isChecked)
-                })
-                const hasFilledCheckedTextboxes = val.subquestion3.every((substatement: any) => {
-                    const hasCheckedAndFilled = substatement.isChecked ? substatement.isChecked && !!substatement.answer : true
-                    return hasCheckedAndFilled
-                })
-                const canConfirm =  hasFilledAllScalesZeros ? 
-                    hasFilledScales  : 
-                    hasFilledScales 
-                        && hasFilledAtLeastOneTextbox 
-                        && hasFilledCheckedTextboxes
-                
-                this.isLoaded && this.$emit('input', canConfirm)
-            }
-        },
-        scaleValues: {
-            deep: true,
-            handler(val) {
-                if(val.length) {
-                    const keys = ['subquestion1', 'subquestion2']
-                    keys.forEach((key)=> {
-                        const polishAnnotation : any = _.get(this.polishAnnotation.offensive, key)
-                        const scaleValue = val.find((scale: any)=> scale.text === polishAnnotation)
-                        if(scaleValue) {
-                            _.set(this.formData, `${key}.value`, scaleValue.scale)
-                            _.set(this.formData, `${key}.isClicked`, true)
-                            _.set(this.formData, `${key}.isSubmitting`, false)
-                        } 
-                    })
-                } else {
-                    this.formData = {
-                        ...this.formData, 
-                        ...{
-                            subquestion1: _.cloneDeep(this.originalFormData.subquestion1),
-                            subquestion2: _.cloneDeep(this.originalFormData.subquestion2),
-                        }
-                    }
-                }
-            }
-        },
-        textLabelValues: {
-            deep: true,
-            handler(val) {
-                if(val.length) {
-                    const keys = ['subquestion3', 'subquestion4']
-                    val.forEach((textLabel : any) => {
-                        const substatementIndex = textLabel.substatementKey.split('.substatement')[1]
-                        const subquestionIndex = textLabel.substatementKey.split(".")[0]
-                        const formDataKey = `${subquestionIndex}[${parseInt(substatementIndex)-1}]`
-                        const formData = _.get(this.formData, formDataKey)
-                        if(formData) {
-                            _.set(this.formData, `${formDataKey}.isChecked`, !!textLabel.text)
-                            _.set(this.formData, `${formDataKey}.isSubmitting`, false)
-                            _.set(this.formData, `${formDataKey}.answer`, textLabel.text)
-                        } 
-                    }) 
-                    keys.forEach((key)=> {
-                        // @ts-ignore
-                        const subquestionLength = this.formData[key].length
-                        for(let i : number= 0; i < subquestionLength; i++) {
-                            const substatementKey = `${key}.substatement${i+1}`
-                            const isStored = val.find((textLabel: any)=> textLabel.substatementKey === substatementKey)
-                            if(!isStored) {
-                                // @ts-ignore
-                                this.formData[key][i].answer = ''
-                                // @ts-ignore
-                                this.formData[key][i].isSubmitting = false
-                            }
-                        }
-                    })
-                } else {
-                    this.formData = {
-                        ...this.formData, 
-                        ...{
-                            subquestion3: _.cloneDeep(this.originalFormData.subquestion3),
-                            subquestion4: _.cloneDeep(this.originalFormData.subquestion4)
-                        }
-                    }
-                }            
-
-            }
-        }
-    },
-    async created() {
-        await this.setOriginalFormData()
-        this.$nextTick(()=> {
-            this.formData = _.cloneDeep(this.originalFormData)
-        })
-    },
-    mounted() {
-        this.isLoaded = true;
-    },
-    methods: {
-        setOriginalFormData() {
-            const keys = ['subquestion3', 'subquestion4']
-            const annotation : any = this.polishAnnotation.offensive
-            keys.forEach((key)=> {
-                let subquestionLength = 0
-                const substatement = Object.keys(annotation[key])
-                    .reverse()
-                    .find((annKey)=> annKey.includes('substatement'))
-                if(substatement) {
-                    subquestionLength = parseInt(substatement.replace( /^\D+/g, ''))
-                }
-                for(let i = 0; i < subquestionLength; i++) {
-                    // @ts-ignore
-                    this.originalFormData[key].push({
-                        isSubmitting: false,
-                        isChecked: false,
-                        answer: key === 'subquestion4' ? undefined : ""
-                    })
-                }
-            })
-        },
-        onScaleChange: _.debounce(function (formDataKey: string) {
-            // @ts-ignore
-            const base = this as any
-            _.set(base.formData, `${formDataKey}.isClicked`, true)
-            const formData : any = _.get(base.formData, formDataKey) 
-            const labelQuestion : string = base.polishAnnotation.offensive[formDataKey]
-            const scaleLabel : any = base.scaleTypes.find((scaleType: any)=> scaleType.text === labelQuestion)
-            if(scaleLabel && base.isLoaded && !formData.isSubmitting) {
-                _.set(base.formData, `${formData.isSubmitting}`, true)
-                base.$emit('update:scale', scaleLabel.id, formData.value)
-            } 
-        }, 100),
-        onLabelChange(substatement: any, key: string, index: number) {
-            const formDataKey = `${key}[${index}]`
-            const labelQuestionKey = `${key}.substatement${index+1}`
-            const formData = _.get(this.formData, formDataKey)
-            const labelQuestion = _.get(this.polishAnnotation.offensive, labelQuestionKey)
-            const parentQuestion = _.get(this.polishAnnotation.offensive, key+'.question')
-            const question = `${parentQuestion} - ${labelQuestion}`
-
-            const textLabelValue = this.textLabelValues.find((textLabel : any) => textLabel.question === question)
-            let eventName = textLabelValue ? 'update:label' : 'add:label'
-            eventName = substatement.isChecked ? eventName : 'remove:label'
-            if(!_.isEmpty(formData) && labelQuestion) {
-                const answer = formData.answer === undefined ? labelQuestion : formData.answer
-                if(eventName === 'add:label' && answer) {
-                    this.$emit(eventName, question, answer)
-                } else if(eventName === 'update:label' && textLabelValue) {
-                    const substatementId = textLabelValue.id
-                    this.$emit(eventName, substatementId, answer)
-                } else if(eventName === 'remove:label' && textLabelValue) {
-                    const substatementId = textLabelValue.id
-                    this.$emit(eventName, substatementId)
-                }
-                _.set(this.formData, formDataKey+".isSubmitting", !!answer)
-            } 
-        }
+        subquestion3: [],
+        subquestion4: []
+      }
     }
+  },
+  computed: {
+    hasProperScaleTypes(): boolean {
+      const scaleLabels = [
+        this.polishAnnotation.offensive.subquestion1,
+        this.polishAnnotation.offensive.subquestion2
+      ]
+      const scaleTypeTexts = _.flatMap(this.scaleTypes, 'text')
+      return _.intersectionBy(scaleLabels, scaleTypeTexts).length > 0
+    },
+    scaleValues(): any[] {
+      return this.scales.map((scale: any) => {
+        const scaleType: any =
+          this.scaleTypes.find((scaleType: any) => scaleType.id === scale.label) || {}
+        return {
+          ...scale,
+          ...scaleType,
+          scaleTypeId: scale.label
+        }
+      })
+    },
+    textLabelValues(): any[] {
+      return this.textLabels.map((textLabel: any) => {
+        const substatementQuestion = textLabel.question
+        const annotation = _.cloneDeep(this.polishAnnotation.offensive) as any
+        let substatementKey = ''
+        Object.keys(annotation).forEach((subKey: string) => {
+          if (typeof annotation[subKey] === 'object') {
+            Object.keys(annotation[subKey]).every((subKey2: string) => {
+              let isKey = annotation[subKey][subKey2] === textLabel.question
+              if (textLabel.question.includes(' - ')) {
+                const questions = textLabel.question.split(' - ')
+                isKey =
+                  annotation[subKey].question === questions[0] &&
+                  annotation[subKey][subKey2] === questions[1]
+              }
+              if (isKey) {
+                substatementKey = `${subKey}.${subKey2}`
+              }
+              return !isKey
+            })
+          }
+        })
+        return {
+          ...textLabel,
+          substatementQuestion,
+          substatementKey
+        }
+      })
+    },
+    zeroToTenLabels(): number[] {
+      return Array.from(Array(11).keys())
+    },
+    hasFilledTopQuestions(): boolean {
+      return !!this.formData.subquestion1.value || !!this.formData.subquestion2.value
+    }
+  },
+  watch: {
+    doc() {
+      this.formData = _.cloneDeep(this.originalFormData)
+      this.$forceUpdate()
+    },
+    formData: {
+      deep: true,
+      handler(val: any) {
+        const scaleKeys = ['subquestion1', 'subquestion2']
+        const labelKeys = ['subquestion3', 'subquestion4']
+        const hasFilledScales = scaleKeys.some((scaleKey) => {
+          return val[scaleKey].isClicked
+        })
+        const hasFilledAllScalesZeros = scaleKeys.every((scaleKey) => {
+          return val[scaleKey].value === 0
+        })
+        const hasFilledAtLeastOneTextbox = labelKeys.some((labelKey) => {
+          return val[labelKey].some((formData: any) => formData.isChecked)
+        })
+        const hasFilledCheckedTextboxes = val.subquestion3.every((substatement: any) => {
+          const hasCheckedAndFilled = substatement.isChecked
+            ? substatement.isChecked && !!substatement.answer
+            : true
+          return hasCheckedAndFilled
+        })
+        const canConfirm = hasFilledAllScalesZeros
+          ? hasFilledScales
+          : hasFilledScales && hasFilledAtLeastOneTextbox && hasFilledCheckedTextboxes
+
+        this.isLoaded && this.$emit('input', canConfirm)
+      }
+    },
+    scaleValues: {
+      deep: true,
+      handler(val) {
+        if (val.length) {
+          const keys = ['subquestion1', 'subquestion2']
+          keys.forEach((key) => {
+            const polishAnnotation: any = _.get(this.polishAnnotation.offensive, key)
+            const scaleValue = val.find((scale: any) => scale.text === polishAnnotation)
+            if (scaleValue) {
+              _.set(this.formData, `${key}.value`, scaleValue.scale)
+              _.set(this.formData, `${key}.isClicked`, true)
+              _.set(this.formData, `${key}.isSubmitting`, false)
+            }
+          })
+        } else {
+          this.formData = {
+            ...this.formData,
+            ...{
+              subquestion1: _.cloneDeep(this.originalFormData.subquestion1),
+              subquestion2: _.cloneDeep(this.originalFormData.subquestion2)
+            }
+          }
+        }
+      }
+    },
+    textLabelValues: {
+      deep: true,
+      handler(val) {
+        if (val.length) {
+          const keys = ['subquestion3', 'subquestion4']
+          val.forEach((textLabel: any) => {
+            const substatementIndex = textLabel.substatementKey.split('.substatement')[1]
+            const subquestionIndex = textLabel.substatementKey.split('.')[0]
+            const formDataKey = `${subquestionIndex}[${parseInt(substatementIndex) - 1}]`
+            const formData = _.get(this.formData, formDataKey)
+            if (formData) {
+              _.set(this.formData, `${formDataKey}.isChecked`, !!textLabel.text)
+              _.set(this.formData, `${formDataKey}.isSubmitting`, false)
+              _.set(this.formData, `${formDataKey}.answer`, textLabel.text)
+            }
+          })
+          keys.forEach((key) => {
+            // @ts-ignore
+            const subquestionLength = this.formData[key].length
+            for (let i: number = 0; i < subquestionLength; i++) {
+              const substatementKey = `${key}.substatement${i + 1}`
+              const isStored = val.find(
+                (textLabel: any) => textLabel.substatementKey === substatementKey
+              )
+              if (!isStored) {
+                // @ts-ignore
+                this.formData[key][i].answer = ''
+                // @ts-ignore
+                this.formData[key][i].isSubmitting = false
+              }
+            }
+          })
+        } else {
+          this.formData = {
+            ...this.formData,
+            ...{
+              subquestion3: _.cloneDeep(this.originalFormData.subquestion3),
+              subquestion4: _.cloneDeep(this.originalFormData.subquestion4)
+            }
+          }
+        }
+      }
+    }
+  },
+  async created() {
+    await this.setOriginalFormData()
+    this.$nextTick(() => {
+      this.formData = _.cloneDeep(this.originalFormData)
+    })
+  },
+  mounted() {
+    this.isLoaded = true
+  },
+  methods: {
+    setOriginalFormData() {
+      const keys = ['subquestion3', 'subquestion4']
+      const showTextboxIndexes = {
+        subquestion3: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+        subquestion4: [8]
+      }
+      const annotation: any = this.polishAnnotation.offensive
+      keys.forEach((key) => {
+        let subquestionLength = 0
+        const substatement = Object.keys(annotation[key])
+          .reverse()
+          .find((annKey) => annKey.includes('substatement'))
+        if (substatement) {
+          subquestionLength = parseInt(substatement.replace(/^\D+/g, ''))
+        }
+        for (let i = 0; i < subquestionLength; i++) {
+          // @ts-ignore
+          this.originalFormData[key].push({
+            isSubmitting: false,
+            isChecked: false,
+            showTextbox: showTextboxIndexes[key].includes(i + 1),
+            answer: ''
+          })
+        }
+      })
+    },
+    onScaleChange: _.debounce(function (formDataKey: string) {
+      // @ts-ignore
+      const base = this as any
+      _.set(base.formData, `${formDataKey}.isClicked`, true)
+      const formData: any = _.get(base.formData, formDataKey)
+      const labelQuestion: string = base.polishAnnotation.offensive[formDataKey]
+      const scaleLabel: any = base.scaleTypes.find(
+        (scaleType: any) => scaleType.text === labelQuestion
+      )
+      if (scaleLabel && base.isLoaded && !formData.isSubmitting) {
+        _.set(base.formData, `${formData.isSubmitting}`, true)
+        base.$emit('update:scale', scaleLabel.id, formData.value)
+      }
+    }, 100),
+    onLabelChange(substatement: any, key: string, index: number) {
+      const formDataKey = `${key}[${index}]`
+      const labelQuestionKey = `${key}.substatement${index + 1}`
+      const formData = _.get(this.formData, formDataKey)
+      const labelQuestion = _.get(this.polishAnnotation.offensive, labelQuestionKey)
+      const parentQuestion = _.get(this.polishAnnotation.offensive, key + '.question')
+      const question = `${parentQuestion} - ${labelQuestion}`
+
+      const textLabelValue = this.textLabelValues.find(
+        (textLabel: any) => textLabel.question === question
+      )
+      let eventName = textLabelValue ? 'update:label' : 'add:label'
+      eventName = substatement.isChecked ? eventName : 'remove:label'
+      if (!_.isEmpty(formData) && labelQuestion) {
+        const textfieldAnswer = formData.showTextbox && !formData.answer ? '-' : formData.answer
+        const answer = formData.showTextbox ? textfieldAnswer : labelQuestion
+        if (eventName === 'add:label' && answer) {
+          this.$emit(eventName, question, answer)
+        } else if (eventName === 'update:label' && textLabelValue) {
+          const substatementId = textLabelValue.id
+          this.$emit(eventName, substatementId, answer)
+        } else if (eventName === 'remove:label' && textLabelValue) {
+          const substatementId = textLabelValue.id
+          this.$emit(eventName, substatementId)
+        }
+        _.set(this.formData, formDataKey + '.isSubmitting', !!answer)
+      }
+    }
+  }
 })
 </script>
 <style lang="scss">
 .offensive-input {
-    overflow-y: auto;
+  overflow-y: auto;
 
-    &.--bordered {
-        border: 2px solid #ddd;
-        border-radius: 2px;  
+  &.--bordered {
+    border: 2px solid #ddd;
+    border-radius: 2px;
 
-        &.--has-error {
-            border: 2px solid red;
-        }
+    &.--has-error {
+      border: 2px solid red;
     }
-
+  }
 }
 
 .widget {
-    font-size: .8rem;
+  font-size: 0.8rem;
 
-    &__title {
-        font-size: 1rem;
-        font-weight: bold;
-        margin-bottom: 10px; 
-    }
+  &__title {
+    font-size: 1rem;
+    font-weight: bold;
+    margin-bottom: 10px;
+  }
 
-    &__questions {
-        padding: none;
-    }
+  &__questions {
+    padding: none;
+  }
 }
 
 .questions-item {
-    opacity: .3;
+  opacity: 0.3;
 
-    &.--visible {
-        opacity: 1;
+  &.--visible {
+    opacity: 1;
+  }
+
+  &__slider {
+    display: flex;
+
+    .v-slider__tick-label {
+      font-size: 0.8rem;
     }
 
-    &__slider {
-        display: flex;
+    .slider-text {
+      color: gray;
+      margin-top: 5px;
 
-        .v-slider__tick-label {
-            font-size: .8rem;
-        }
+      &.--start {
+        margin-right: 10px;
+      }
 
-        .slider-text {
-            color: gray;
-            margin-top: 5px; 
-
-            &.--start {
-                margin-right: 10px;
-            }
-
-            &.--end {
-                margin-left: 10px;
-            }
-        }
+      &.--end {
+        margin-left: 10px;
+      }
     }
-
+  }
 }
 
 .subquestions {
-    list-style-type: none;
-    padding: 0;
-    
-    &__item {
-        .subquestions-item__checkbox {
-            .v-label {
-                font-size: .8rem;
-            }
+  list-style-type: none;
+  padding: 0;
 
-            .v-input__slot {
-                margin: 0
-            }
-        }
+  &__item {
+    .subquestions-item__checkbox {
+      .v-label {
+        font-size: 0.8rem;
+      }
+
+      .v-input__slot {
+        margin: 0;
+      }
     }
+  }
 }
 </style>

--- a/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
@@ -409,7 +409,7 @@ export default Vue.extend({
   methods: {
     setOriginalFormData() {
       const keys = ['subquestion3', 'subquestion4']
-      const showTextboxIndexes = {
+      const showTextboxIndexes: any = {
         subquestion3: [1, 2, 3, 4, 5, 6, 7, 8, 9],
         subquestion4: [8]
       }

--- a/frontend/domain/models/example/example.ts
+++ b/frontend/domain/models/example/example.ts
@@ -60,6 +60,28 @@ export class ExampleItem {
   }
 }
 
+export class ExampleStateItem {
+  id: number
+  example: number
+  
+  @Expose({ name: "confirmed_at"})
+  confirmedAt: String
+
+  @Expose({name: "confirmed_by"})
+  confirmedBy: number
+}
+
+export class ExampleStateItemList {
+  count: number
+  next: string | null
+  prev: string | null
+
+  @Type(() => ExampleStateItem)
+  @Expose({ name: 'results' })
+  items: ExampleStateItem[]
+}
+
+
 export class ExampleItemList {
   count: number
   next: string | null

--- a/frontend/domain/models/example/exampleRepository.ts
+++ b/frontend/domain/models/example/exampleRepository.ts
@@ -1,4 +1,4 @@
-import { ExampleItem, ExampleItemList } from '~/domain/models/example/example'
+import { ExampleItem, ExampleItemList, ExampleStateItemList } from '~/domain/models/example/example'
 
 export type SearchOption = { [key: string]: string | (string | null)[] }
 
@@ -20,4 +20,6 @@ export interface ExampleRepository {
   confirm(projectId: string, exampleId: number): Promise<void>
 
   annotateStartStates(projectId: string, exampleId: number): Promise<void>
+
+  listStates(projectId: string, exampleId: number): Promise<ExampleStateItemList>
 }

--- a/frontend/domain/models/questionnaire/questionnaire.ts
+++ b/frontend/domain/models/questionnaire/questionnaire.ts
@@ -52,6 +52,17 @@ export class AnswerWriteItem {
     }
 }
 
+export class QuestionnaireTimeItem {
+  id: number
+  questionnaire: number
+  
+  @Expose({ name: 'finished_by' })
+  finishedBy: number
+
+  @Expose({ name: 'finished_at' })
+  finishedAt: String
+}
+
 export class QuestionnaireTypeItemList {
     count: number
     next: string | null
@@ -60,6 +71,17 @@ export class QuestionnaireTypeItemList {
     @Type(() => QuestionnaireTypeItem)
     @Expose({ name: 'results' })
     items: QuestionnaireTypeItem[]
+  }
+
+
+  export class QuestionnaireTimeItemList {
+    count: number
+    next: string | null
+    previous: string | null
+  
+    @Type(() => QuestionnaireTimeItem)
+    @Expose({ name: 'results' })
+    items: QuestionnaireTimeItem[]
   }
 
 

--- a/frontend/domain/models/questionnaire/questionnaireRepository.ts
+++ b/frontend/domain/models/questionnaire/questionnaireRepository.ts
@@ -3,7 +3,9 @@ import {
   QuestionnaireTypeItemList, 
   QuestionnaireItemList, 
   AnswerReadItem, 
-  AnswerWriteItem} 
+  AnswerWriteItem,
+  QuestionnaireTimeItem,
+  QuestionnaireTimeItemList} 
 from '~/domain/models/questionnaire/questionnaire'
 
 export type SearchOption = { [key: string]: string | (string | null)[] }
@@ -15,8 +17,12 @@ export interface QuestionnaireRepository {
 
   listQuestionsByQuestionnaireId({ questionnaireId, limit, offset, q }: SearchOption): Promise<QuestionItemList>
 
+  listFinishedQuestionnaires({limit, offset, q}: SearchOption): Promise<QuestionnaireTimeItemList>
+
   createAnswer(item: AnswerWriteItem): Promise<AnswerReadItem>
 
   updateAnswer(item: AnswerWriteItem): Promise<AnswerReadItem>
+
+  createQuestionnaireFinishedState(questionnaireId: number): Promise<QuestionnaireTimeItem>
 
 }

--- a/frontend/domain/models/questionnaire/questionnaireRepository.ts
+++ b/frontend/domain/models/questionnaire/questionnaireRepository.ts
@@ -8,7 +8,7 @@ import {
   QuestionnaireTimeItemList} 
 from '~/domain/models/questionnaire/questionnaire'
 
-export type SearchOption = { [key: string]: string | (string | null)[] }
+export type SearchOption = { [key: string]: number | string | (string | null)[] }
 
 export interface QuestionnaireRepository {
   listTypes({ limit, offset, q }: SearchOption): Promise<QuestionnaireTypeItemList>

--- a/frontend/i18n/de/projects/annotation.js
+++ b/frontend/i18n/de/projects/annotation.js
@@ -127,7 +127,8 @@ export default {
       substatement5: "Unfaire Verallgemeinerung, Stereotypisierung",
       substatement6: "Respektlosigkeit",
       substatement7: "Erniedrigung",
-      substatement8: "Sonstiges"
+      substatement8: "Sonstiges",
+      substatement8Question: "Welche Art?"
     }
   },
   humor: {

--- a/frontend/i18n/en/projects/annotation.js
+++ b/frontend/i18n/en/projects/annotation.js
@@ -128,7 +128,8 @@ export default {
       substatement5: "unfair generalization, stereotyping",
       substatement6: "disrespect",
       substatement7: "humiliation",
-      substatement8: "other"
+      substatement8: "other",
+      substatement8Question: "What kind?"
     }
   },
   humor: {

--- a/frontend/i18n/fr/projects/annotation.js
+++ b/frontend/i18n/fr/projects/annotation.js
@@ -127,7 +127,8 @@ export default {
       substatement5: "généralisation injuste, stéréotypes",
       substatement6: "manque de respect",
       substatement7: "humiliation",
-      substatement8: "autre"
+      substatement8: "autre",
+      substatement8Question: "Laquelle ?"
     }
   },
   humor: {

--- a/frontend/i18n/pl/projects/annotation.js
+++ b/frontend/i18n/pl/projects/annotation.js
@@ -128,7 +128,8 @@ export default {
       substatement5: "Niesprawiedliwe uogólnianie, stereotypy",
       substatement6: "Lekceważenie",
       substatement7: "Upokorzenie",
-      substatement8: "Inne"
+      substatement8: "Inne",
+      substatement8Question: "Jakie?",
     }
   },
   humor: {

--- a/frontend/i18n/zh/projects/annotation.js
+++ b/frontend/i18n/zh/projects/annotation.js
@@ -130,7 +130,8 @@ export default {
       substatement5: "不公平的概括, 陈规定型",
       substatement6: "不尊重",
       substatement7: "羞辱",
-      substatement8: "其他"
+      substatement8: "其他",
+      substatement8Question:"什么类型？"
     }
   },
   humor: {

--- a/frontend/layouts/projects.vue
+++ b/frontend/layouts/projects.vue
@@ -17,6 +17,7 @@
 import TheHeader from '~/components/layout/TheHeader'
 
 export default {
+  name: 'Projects',
   components: {
     TheHeader
   }

--- a/frontend/layouts/questionnaires.vue
+++ b/frontend/layouts/questionnaires.vue
@@ -17,9 +17,10 @@
 import TheHeader from '~/components/layout/TheHeader'
 
 export default {
+  name: 'Questionnaires',
   components: {
     TheHeader
   },
-  middleware: ['check-auth', 'auth', 'check-questionnaire'],
+  middleware: ['check-auth', 'auth', 'check-questionnaire']
 }
 </script>

--- a/frontend/middleware/check-questionnaire.js
+++ b/frontend/middleware/check-questionnaire.js
@@ -14,11 +14,11 @@ export default function ({ store, route, redirect, app }) {
         const locale = app.i18n.locale ?? 'pl'
         
         if(!isStaff && toShow.length && !isOnQuestionnairePage) {
-            return redirect(locale + "/questionnaires")
+            return redirect("/"+ locale + "/questionnaires")
         } 
         else if(!isStaff && toShow.length && isOnQuestionnairePage) {
             if(isWorkingNow && (isOnMainQuestionnairePage || !route.path.includes(key))) { 
-                redirect(`${locale}/questionnaires/${key}`)
+                redirect(`/${locale}/questionnaires/${key}`)
             }
         }
     } else if(hasValidToShow && !toShow.length && isOnQuestionnairePage)  {

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -520,7 +520,7 @@ export default {
             let firstQuestionnaireEverDate = null
             if (questionnaireStates && questionnaireStates.items.length > 0) {
               const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
-              firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+              firstQuestionnaireEverDate = moment(String(firstQuestionnaireEver)).format('DD-MM-YYYY')
             }
             this.initQuestionnaire(firstQuestionnaireEverDate)
           })

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -512,7 +512,15 @@ export default {
       handler(val) {
         const textBatchCount = 20
         if (val.textCountToday > 0 && val.textCountToday % textBatchCount === 0) {
-          this.initQuestionnaire()
+          this.$nextTick(async () => {
+            const questionnaireStates = await this.$services.questionnaire.listFinishedQuestionnaires({
+              questionnaireTypeId: 1,
+              limit: 1
+            })
+            const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
+            const firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+            this.initQuestionnaire(firstQuestionnaireEverDate)
+          })
         }
       }
     },

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -517,8 +517,11 @@ export default {
               questionnaireTypeId: 1,
               limit: 1
             })
-            const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
-            const firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+            let firstQuestionnaireEverDate = null
+            if (questionnaireStates) {
+              const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
+              firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+            }
             this.initQuestionnaire(firstQuestionnaireEverDate)
           })
         }

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -90,7 +90,7 @@
                 {{ doc.text }}
               </p>
             </v-col>
-            <v-col cols="12" md="3">
+            <v-col cols="12" md="3" class="d-sm-none d-md-block">
               <annotation-progress :progress="progress" />
             </v-col>
           </v-row>

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -518,7 +518,7 @@ export default {
               limit: 1
             })
             let firstQuestionnaireEverDate = null
-            if (questionnaireStates) {
+            if (questionnaireStates && questionnaireStates.items.length > 0) {
               const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
               firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
             }

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -737,7 +737,6 @@ export default {
         this.categories = await this.$services.textClassification.list(this.projectId, docId)
         this.textLabels = await this.$services.affectiveTextlabel.list(this.projectId, docId)
         this.scales = await this.$services.affectiveScale.list(this.projectId, docId)
-
         this.setAffectiveList()
       }
     },

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -565,14 +565,6 @@ export default {
         if (entityEditor) {
           const { bottom } = entityEditor.$el.getBoundingClientRect()
           this.hasStickyView = bottom + margin < 100
-
-          const component = this.isCombinationMode
-            ? this.$refs.summaryInput
-            : this.getDimensionComponentRef()
-          console.log(component)
-          if (component && component.isVisible()) {
-            console.log('test')
-          }
         }
       }
     }, 100),
@@ -881,6 +873,7 @@ export default {
           lastAnnotationTime: moment().format(DATE_FORMAT)
         })
         this.hasClickedConfirmButton = false
+        this.scrollToTop()
       }
     },
     isAllAffectiveSummaryAdded() {

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="affective-annotation" v-show="isLoaded">
+  <div v-show="isLoaded" class="affective-annotation">
     <layout-text
       v-if="doc.id"
       v-shortkey="shortKeysSpans"
@@ -86,7 +86,7 @@
           <toolbar-mobile :total="docs.count" class="d-flex d-sm-none header-toolbar --mobile" />
           <v-row v-show="hasStickyView">
             <v-col cols="12" md="9">
-              <p class="header-text" ref="entityText">
+              <p ref="entityText" class="header-text">
                 {{ doc.text }}
               </p>
             </v-col>
@@ -144,9 +144,9 @@
                 <v-divider />
                 <div class="annotation-card__text pa-4" :class="{ '--sticky': hasStickyView }">
                   <entity-editor
+                    ref="entityEditor"
                     class="entity-editor"
                     :class="{ '--transparent': hasStickyView }"
-                    ref="entityEditor"
                     :dark="$vuetify.theme.dark"
                     :rtl="isRTL"
                     :read-only="!canEdit"
@@ -171,8 +171,8 @@
               <v-divider />
               <v-card
                 v-if="isScaleImported"
-                class="pa-4 dimension-card"
                 ref="dimensionCard"
+                class="pa-4 dimension-card"
                 :style="`margin-top: ${
                   hasStickyView ? $refs.entityEditor.$el.clientHeight / 2 : 0
                 }px`"
@@ -197,8 +197,8 @@
                 />
                 <emotions-input
                   v-if="project.isEmotionsMode || project.isCombinationMode"
-                  class="mb-10"
                   ref="emotionsInput"
+                  class="mb-10"
                   :read-only="!canEdit"
                   :show-borders="project.isCombinationMode"
                   :show-errors="!hasValidEntries.isEmotionsMode && hasClickedConfirmButton"
@@ -218,8 +218,8 @@
                 />
                 <others-input
                   v-if="project.isOthersMode || project.isCombinationMode"
-                  class="mb-10"
                   ref="othersInput"
+                  class="mb-10"
                   :read-only="!canEdit"
                   :show-borders="project.isCombinationMode"
                   :show-errors="!hasValidEntries.isOthersMode && hasClickedConfirmButton"
@@ -245,9 +245,9 @@
                 />
                 <offensive-input
                   v-if="project.isOffensiveMode || project.isCombinationMode"
+                  ref="offensiveInput"
                   v-model="hasValidEntries.isOffensiveMode"
                   class="mb-10"
-                  ref="offensiveInput"
                   :show-borders="project.isCombinationMode"
                   :show-errors="hasClickedConfirmButton"
                   :project="project"
@@ -263,8 +263,8 @@
                 />
                 <humor-input
                   v-if="project.isHumorMode || project.isCombinationMode"
-                  v-model="hasValidEntries.isHumorMode"
                   ref="humorInput"
+                  v-model="hasValidEntries.isHumorMode"
                   class="mb-10"
                   :show-borders="project.isCombinationMode"
                   :show-errors="hasClickedConfirmButton"

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -1,85 +1,104 @@
 <template>
-  <div v-show="isLoaded">
-    <layout-text v-if="doc.id" v-shortkey="shortKeysSpans" @shortkey="changeSelectedLabel">
+  <div class="affective-annotation" v-show="isLoaded">
+    <layout-text
+      v-if="doc.id"
+      v-shortkey="shortKeysSpans"
+      class="layout-text"
+      :class="{ '--sticky': hasStickyView }"
+      @shortkey="changeSelectedLabel"
+    >
       <template #header>
-        <v-alert
-          :value="!canConfirm && hasClickedConfirmButton"
-          color="error"
-          dark
-          transition="scale-transition"
-          dismissible
-          @input="onConfirmationAlertClose"
-        >
-          {{ $t('errors.incompleteAffectiveAnnotation') }}
-        </v-alert>
-        <toolbar-laptop
-          :doc-id="doc.id"
-          :button-options="{
-            review: {
-              visible: true,
-              hasText: true,
-              text: {
-                checked: $t('annotation.checkedTooltip'),
-                notChecked: $t('annotation.notCheckedTooltip')
+        <div class="layout-text__header" :class="{ '--sticky': hasStickyView }">
+          <v-alert
+            :value="!canConfirm && hasClickedConfirmButton"
+            class="header-alert"
+            color="error"
+            dark
+            transition="scale-transition"
+            dismissible
+            @input="onConfirmationAlertClose"
+          >
+            {{ $t('errors.incompleteAffectiveAnnotation') }}
+          </v-alert>
+          <toolbar-laptop
+            :doc-id="doc.id"
+            :button-options="{
+              review: {
+                visible: true,
+                hasText: true,
+                text: {
+                  checked: $t('annotation.checkedTooltip'),
+                  notChecked: $t('annotation.notCheckedTooltip')
+                },
+                disabled: !canEdit
               },
-              disabled: !canEdit
-            },
-            filter: {
-              visible: showFilterButton
-            },
-            guideline: {
-              visible: true
-            },
-            comment: {
-              visible: true
-            },
-            autoLabeling: {
-              visible: showAutoLabeling
-            },
-            clear: {
-              visible: true,
-              disabled: !canEdit
-            },
-            pagination: {
-              visible: true,
-              disabled: {
-                first: !canNavigateBackward,
-                prev: !canNavigateBackward,
-                next: !canNavigateForward,
-                last: !canNavigateForward || !canSkipForward,
-                jump: !canSkipForward
+              filter: {
+                visible: showFilterButton
               },
-              tooltip: {
-                first: canNavigateBackward ? '' : $t('annotation.warningBackNavigation'),
-                prev: canNavigateBackward ? '' : $t('annotation.warningBackNavigation'),
-                next: canNavigateForward ? '' : $t('annotation.warningCheckedNavigation'),
-                prev: canNavigateBackward ? '' : $t('annotation.warningBackNavigation'),
-                jump: ''
+              guideline: {
+                visible: true
               },
-              callback: {
-                next: annotateStartStates,
-                last: annotateStartStates
+              comment: {
+                visible: true
+              },
+              autoLabeling: {
+                visible: showAutoLabeling
+              },
+              clear: {
+                visible: true,
+                disabled: !canEdit
+              },
+              pagination: {
+                visible: true,
+                disabled: {
+                  first: !canNavigateBackward,
+                  prev: !canNavigateBackward,
+                  next: !canNavigateForward,
+                  last: !canNavigateForward || !canSkipForward,
+                  jump: !canSkipForward
+                },
+                tooltip: {
+                  first: canNavigateBackward ? '' : $t('annotation.warningBackNavigation'),
+                  prev: canNavigateBackward ? '' : $t('annotation.warningBackNavigation'),
+                  next: canNavigateForward ? '' : $t('annotation.warningCheckedNavigation'),
+                  prev: canNavigateBackward ? '' : $t('annotation.warningBackNavigation'),
+                  jump: ''
+                },
+                callback: {
+                  next: annotateStartStates,
+                  last: annotateStartStates
+                }
               }
-            }
-          }"
-          :enable-auto-labeling.sync="enableAutoLabeling"
-          :guideline-text="project.guideline"
-          :is-reviewd="doc.isConfirmed"
-          :total="docs.count"
-          :is-article-project="true"
-          :article-index="articleIndex"
-          :article-total="articleTotal"
-          class="d-none d-sm-block"
-          @click:clear-label="clear"
-          @click:review="confirm"
-        >
-          <v-spacer />
-        </toolbar-laptop>
-        <toolbar-mobile :total="docs.count" class="d-flex d-sm-none" />
+            }"
+            :enable-auto-labeling.sync="enableAutoLabeling"
+            :guideline-text="project.guideline"
+            :is-reviewd="doc.isConfirmed"
+            :total="docs.count"
+            :is-article-project="true"
+            :article-index="articleIndex"
+            :article-total="articleTotal"
+            class="d-none d-sm-block header-toolbar --desktop"
+            @click:clear-label="clear"
+            @click:review="confirm"
+          >
+            <v-spacer />
+          </toolbar-laptop>
+          <toolbar-mobile :total="docs.count" class="d-flex d-sm-none header-toolbar --mobile" />
+          <v-row v-show="hasStickyView">
+            <v-col cols="12" md="9">
+              <p class="header-text" ref="entityText">
+                {{ doc.text }}
+              </p>
+            </v-col>
+            <v-col cols="12" md="3">
+              <annotation-progress :progress="progress" />
+            </v-col>
+          </v-row>
+        </div>
       </template>
       <template #content>
-        <div>
-          <v-row>
+        <div class="layout-text__content" :class="{ '--expanded': hasStickyView }">
+          <v-row class="content__title">
             <v-col cols="12">
               <h3 class="mt-3 mb-2">
                 {{ doc.meta.meta.article_title }}
@@ -87,23 +106,22 @@
               <v-divider />
             </v-col>
           </v-row>
-          <v-row class="mt-3">
-            <v-col v-if="showArticleViewer" cols="5">
-              <div>
-                <toolbar-article
-                  :project="project"
-                  :article-items="currentWholeArticle.items"
-                  :current-article-item="doc"
-                />
-              </div>
+          <v-row class="mt-3 content__article">
+            <v-col v-if="showArticleViewer" cols="5" class="content-article__toolbar">
+              <toolbar-article
+                :project="project"
+                :article-items="currentWholeArticle.items"
+                :current-article-item="doc"
+              />
             </v-col>
-            <v-col :cols="showArticleViewer ? 7 : 12" class="annotation-container">
+            <v-col :cols="showArticleViewer ? 7 : 12" class="content-article__container">
               <v-card
                 v-shortkey="shortKeysCategory"
                 class="annotation-card"
+                :class="{ '--sticky': hasStickyView }"
                 @shortkey="addOrRemoveCategory"
               >
-                <v-card-title v-if="categoryTypes.length">
+                <v-card-title v-if="categoryTypes.length" class="annotation-card__title">
                   <label-group
                     v-if="labelOption === 0"
                     :read-only="!canEdit"
@@ -124,8 +142,11 @@
                   />
                 </v-card-title>
                 <v-divider />
-                <div class="annotation-text pa-4">
+                <div class="annotation-card__text pa-4" :class="{ '--sticky': hasStickyView }">
                   <entity-editor
+                    class="entity-editor"
+                    :class="{ '--transparent': hasStickyView }"
+                    ref="entityEditor"
                     :dark="$vuetify.theme.dark"
                     :rtl="isRTL"
                     :read-only="!canEdit"
@@ -148,9 +169,15 @@
                 </div>
               </v-card>
               <v-divider />
-              <v-card v-if="isScaleImported" class="pa-4 dimension-card">
+              <v-card
+                v-if="isScaleImported"
+                class="pa-4 dimension-card"
+                ref="dimensionCard"
+                :class="{ '--sticky': hasStickyView }"
+              >
                 <summary-input
                   v-if="project.isSummaryMode || project.isCombinationMode"
+                  ref="summaryInput"
                   class="mb-10"
                   :text="doc.text"
                   :tags="affectiveSummaryTags"
@@ -254,10 +281,12 @@
         </div>
       </template>
       <template #sidebar>
-        <annotation-progress :progress="progress" />
+        <div class="layout-text__sidebar">
+          <annotation-progress :progress="progress" />
+        </div>
       </template>
+      <resting-period-modal v-if="showRestingMessage" :end-time="restingEndTime" />
     </layout-text>
-    <resting-period-modal v-if="showRestingMessage" :end-time="restingEndTime" />
   </div>
 </template>
 
@@ -363,7 +392,8 @@ export default {
         isEmotionsMode: false,
         isOthersMode: false
       },
-      hasClickedConfirmButton: false
+      hasClickedConfirmButton: false,
+      hasStickyView: false
     }
   },
 
@@ -472,16 +502,15 @@ export default {
       deep: true,
       handler(val) {
         const textBatchCount = 20
-        if(val.textCountToday > 0 && val.textCountToday%textBatchCount === 0) {
+        if (val.textCountToday > 0 && val.textCountToday % textBatchCount === 0) {
           this.initQuestionnaire()
-          
         }
       }
     },
     getQuestionnaire: {
       deep: true,
       handler() {
-        if(valtoShow.length) {
+        if (valtoShow.length) {
           this.$router.push(this.localePath('/questionnaires'))
         }
       }
@@ -504,13 +533,37 @@ export default {
     }
   },
 
+  beforeMount() {
+    window.addEventListener('scroll', this.onScrollListener)
+  },
+
+  beforeDestroy() {
+    window.removeEventListener('scroll', this.onScrollListener)
+  },
+
   mounted() {
     this.isLoaded = true
   },
 
   methods: {
-    ...mapActions('user', ['setRestingPeriod', 'calculateRestingPeriod', 
-      'setAnnotation', 'initQuestionnaire', 'getQuestionnaire']),
+    ...mapActions('user', [
+      'setRestingPeriod',
+      'calculateRestingPeriod',
+      'setAnnotation',
+      'initQuestionnaire',
+      'getQuestionnaire'
+    ]),
+
+    onScrollListener: _.debounce(function () {
+      if (this.isLoaded) {
+        const entityEditor = this.$refs.entityEditor
+        const margin = 100
+        if (entityEditor) {
+          const { bottom } = entityEditor.$el.getBoundingClientRect()
+          this.hasStickyView = bottom + margin < 100
+        }
+      }
+    }, 100),
 
     async checkRestingPeriod() {
       const restingEndTime = await this.calculateRestingPeriod()
@@ -774,8 +827,8 @@ export default {
       }
     },
     async confirm() {
-      const DATE_FORMAT = "DD-MM-YYYY HH:mm:ss"
-      if(this.project.isCombinationMode) {
+      const DATE_FORMAT = 'DD-MM-YYYY HH:mm:ss'
+      if (this.project.isCombinationMode) {
         this.hasValidEntries.isSummaryMode = this.isAllAffectiveSummaryAdded()
         this.hasValidEntries.isOthersMode = this.isAllAffectiveOthersAdded()
         this.hasValidEntries.isEmotionsMode = this.isAllAffectiveEmotionsAdded()
@@ -791,9 +844,11 @@ export default {
         await this.$services.example.confirm(this.projectId, this.doc.id)
         await this.$fetch()
         this.updateProgress()
-        const textCountToday = this.doc.isConfirmed ? this.getAnnotation.textCountToday+1 : this.getAnnotation.textCountToday
-        this.setAnnotation({ 
-          hasAnnotatedToday: true, 
+        const textCountToday = this.doc.isConfirmed
+          ? this.getAnnotation.textCountToday + 1
+          : this.getAnnotation.textCountToday
+        this.setAnnotation({
+          hasAnnotatedToday: true,
           textCountToday,
           lastAnnotationTime: moment().format(DATE_FORMAT)
         })
@@ -984,7 +1039,7 @@ export default {
     scrollToTop() {
       window.scrollTo({
         top: 0,
-        behavior: "smooth"
+        behavior: 'smooth'
       })
     }
   }
@@ -992,35 +1047,57 @@ export default {
 </script>
 
 <style lang="scss" >
-.annotation-text {
-  font-size: 1.1rem !important;
-  font-weight: 500;
-  line-height: 2rem;
-  font-family: 'Roboto', sans-serif !important;
-  opacity: 0.6;
-  margin-bottom: 20px;
+.affective-annotation {
+  .layout-text {
+    position: relative;
+    &__header {
+      &.--sticky {
+        position: sticky;
+        background-color: #fff;
+        padding: 20px;
+        top: 55px;
+        z-index: 1;
+        border: 1px solid #ddd;
+      }
 
-  > div > div > svg:last-of-type {
-    height: 0;
-    overflow: hidden;
+      .header-text {
+        font-size: 0.875rem;
+        margin: 10px 0 0;
+        line-height: 1.5;
+        max-height: 150px;
+        overflow-y: auto;
+      }
+    }
   }
 }
 
-.annotation-container {
+.content-article__container {
   position: relative;
-}
 
-.annotation-card {
-  position: sticky;
-  max-height: 250px;
-  overflow-x: visible;
-  top: 80px;
-  z-index: 1;
-}
+  .annotation-card__text {
+    font-size: 0.875rem;
 
-.dimension-card {
-  position: relative;
-  z-index: 0;
-  margin-top: 60px;
+    > div > div > svg:last-of-type {
+      height: 0;
+      overflow: hidden;
+    }
+
+    .entity-editor {
+      &.--transparent {
+        height: 0;
+        overflow: hidden;
+      }
+    }
+  }
+
+  .dimension-card {
+    position: relative;
+    z-index: 0;
+    margin-top: 60px;
+
+    &.--sticky {
+      top: 300px;
+    }
+  }
 }
 </style>

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -195,6 +195,7 @@
                 <emotions-input
                   v-if="project.isEmotionsMode || project.isCombinationMode"
                   class="mb-10"
+                  ref="emotionsInput"
                   :read-only="!canEdit"
                   :show-borders="project.isCombinationMode"
                   :show-errors="!hasValidEntries.isEmotionsMode && hasClickedConfirmButton"
@@ -215,6 +216,7 @@
                 <others-input
                   v-if="project.isOthersMode || project.isCombinationMode"
                   class="mb-10"
+                  ref="othersInput"
                   :read-only="!canEdit"
                   :show-borders="project.isCombinationMode"
                   :show-errors="!hasValidEntries.isOthersMode && hasClickedConfirmButton"
@@ -242,6 +244,7 @@
                   v-if="project.isOffensiveMode || project.isCombinationMode"
                   v-model="hasValidEntries.isOffensiveMode"
                   class="mb-10"
+                  ref="offensiveInput"
                   :show-borders="project.isCombinationMode"
                   :show-errors="hasClickedConfirmButton"
                   :project="project"
@@ -258,6 +261,7 @@
                 <humor-input
                   v-if="project.isHumorMode || project.isCombinationMode"
                   v-model="hasValidEntries.isHumorMode"
+                  ref="humorInput"
                   class="mb-10"
                   :show-borders="project.isCombinationMode"
                   :show-errors="hasClickedConfirmButton"
@@ -561,9 +565,33 @@ export default {
         if (entityEditor) {
           const { bottom } = entityEditor.$el.getBoundingClientRect()
           this.hasStickyView = bottom + margin < 100
+
+          const component = this.isCombinationMode
+            ? this.$refs.summaryInput
+            : this.getDimensionComponentRef()
+          console.log(component)
+          if (component && component.isVisible()) {
+            console.log('test')
+          }
         }
       }
     }, 100),
+
+    getDimensionComponentRef() {
+      let dimensionRef = 'summaryInput'
+      if (this.isSummaryMode) {
+        dimensionRef = 'summaryInput'
+      } else if (this.isEmotionsMode) {
+        dimensionRef = 'emotionsInput'
+      } else if (this.isOthersMode) {
+        dimensionRef = 'othersInput'
+      } else if (this.isHumorMode) {
+        dimensionRef = 'humorInput'
+      } else if (this.isOffensiveMode) {
+        dimensionRef = 'offensiveInput'
+      }
+      return this.$refs[dimensionRef]
+    },
 
     async checkRestingPeriod() {
       const restingEndTime = await this.calculateRestingPeriod()
@@ -1075,7 +1103,10 @@ export default {
   position: relative;
 
   .annotation-card__text {
-    font-size: 0.875rem;
+    font-size: 1.1rem !important;
+    font-weight: 500;
+    font-family: 'Roboto', sans-serif !important;
+    opacity: 0.6;
 
     > div > div > svg:last-of-type {
       height: 0;

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -566,22 +566,10 @@ export default {
     onScrollListener: _.debounce(function () {
       if (this.isLoaded) {
         const entityEditor = this.$refs.entityEditor
-        const dimensionCard = this.$refs[this.getDimensionComponentRef()]
         const margin = 100
         if (entityEditor) {
           const { bottom } = entityEditor.$el.getBoundingClientRect()
           this.hasStickyView = bottom - margin < 0
-        }
-
-        if (dimensionCard && this.isCombinationMode) {
-          const { y } = dimensionCard.$el.getBoundingClientRect()
-          if (this.hasStickyView && y < 0 && this.firstView) {
-            this.$refs[this.getDimensionComponentRef()].$el.scrollIntoView({
-              block: 'center',
-              behavior: 'smooth'
-            })
-            this.firstView = false
-          }
         }
       }
     }, 50),
@@ -889,9 +877,12 @@ export default {
         const textCountToday = this.doc.isConfirmed
           ? this.getAnnotation.textCountToday + 1
           : this.getAnnotation.textCountToday
+
+        const { firstAnnotationTime } = this.getAnnotation
         this.setAnnotation({
           hasAnnotatedToday: true,
           textCountToday,
+          firstAnnotationTime: firstAnnotationTime ?? moment().format(DATE_FORMAT),
           lastAnnotationTime: moment().format(DATE_FORMAT)
         })
         this.hasClickedConfirmButton = false

--- a/frontend/pages/projects/_id/dataset/index.vue
+++ b/frontend/pages/projects/_id/dataset/index.vue
@@ -1,13 +1,14 @@
 <template>
   <v-card>
     <v-card-title v-if="isProjectAdmin">
-      <v-row >
-        <v-col cols="12" align="right" >
-          <v-btn 
+      <v-row>
+        <v-col cols="12" align="right">
+          <v-btn
             v-if="!showTableAnnButton"
             :disabled="!enableTableAnnButton"
             color="ms-4 my-1 mb-2 primary text-transform-none"
-            @click="toLabeling">
+            @click="toLabeling"
+          >
             {{ $t('home.startAnnotation') }}
           </v-btn>
         </v-col>
@@ -67,11 +68,12 @@
         @view-not-confirmed="isConfirmed = false"
       />
       <v-spacer />
-      <v-btn 
+      <v-btn
         v-if="!showTableAnnButton"
         :disabled="!enableTableAnnButton"
         color="ms-4 my-1 mb-2 primary text-transform-none"
-        @click="toLabeling">
+        @click="toLabeling"
+      >
         {{ $t('home.startAnnotation') }}
       </v-btn>
     </v-card-title>
@@ -120,7 +122,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import _ from 'lodash'
-import { mapActions } from "vuex"
+import { mapActions } from 'vuex'
+import moment from 'moment'
 import ArticleList from '@/components/example/ArticleList.vue'
 import DocumentList from '@/components/example/DocumentList.vue'
 import FormDelete from '@/components/example/FormDelete.vue'
@@ -154,13 +157,16 @@ export default Vue.extend({
   data() {
     return {
       dialogDelete: false,
+      dateFormat: 'DD-MM-YYYY',
+      serverDateFormat: 'YYYY-MM-DDTHH:mm:ss',
+      savedDateFormat: 'DD-MM-YYYY HH:mm:ss',
       dialogDeleteAll: false,
       project: {} as ProjectDTO,
       item: { items: [] as ExampleDTO[] } as ExampleListDTO,
       selected: [] as ExampleDTO[],
       isLoading: false,
       isProjectAdmin: false,
-      isConfirmed: '',
+      isConfirmed: ''
     }
   },
 
@@ -169,7 +175,7 @@ export default Vue.extend({
   },
 
   computed: {
-    annotationConfirmationOptions() : any[] {
+    annotationConfirmationOptions(): any[] {
       return [
         {
           title: this.$t('dataset.viewAllStatus'),
@@ -182,7 +188,7 @@ export default Vue.extend({
         {
           title: this.$t('annotation.notCheckedTooltip'),
           event: 'view-not-confirmed'
-        },
+        }
       ]
     },
     canDelete(): boolean {
@@ -191,17 +197,17 @@ export default Vue.extend({
     projectId(): string {
       return this.$route.params.id
     },
-    enableTableAnnButton() : boolean {
-      return this.isProjectAdmin ? this.hasItems : (this.hasItems && this.hasUnannotatedItem)
+    enableTableAnnButton(): boolean {
+      return this.isProjectAdmin ? this.hasItems : this.hasItems && this.hasUnannotatedItem
     },
-    showTableAnnButton() : boolean {
+    showTableAnnButton(): boolean {
       return this.isArticleTask && this.isProjectAdmin && !this.isAffectiveAnnotation
     },
     isArticleTask(): boolean {
       const articleTasks = ['ArticleAnnotation', 'AffectiveAnnotation']
       return articleTasks.includes(this.project.projectType)
     },
-    isAffectiveAnnotation() : boolean {
+    isAffectiveAnnotation(): boolean {
       return this.project.projectType === 'AffectiveAnnotation'
     },
     isImageTask(): boolean {
@@ -210,10 +216,10 @@ export default Vue.extend({
     isAudioTask(): boolean {
       return this.project.projectType === 'Speech2text'
     },
-    hasItems() : boolean {
+    hasItems(): boolean {
       return !!this.item.items.length
     },
-    hasUnannotatedItem() : boolean {
+    hasUnannotatedItem(): boolean {
       return !!this.item.items.find((item: any) => !item.isConfirmed)
     },
     itemKey(): string {
@@ -222,7 +228,7 @@ export default Vue.extend({
       } else {
         return 'text'
       }
-    },
+    }
   },
 
   watch: {
@@ -243,28 +249,54 @@ export default Vue.extend({
   methods: {
     ...mapActions('user', ['setAnnotation']),
     async toLabeling() {
-      const itemToAnnotate : undefined | ExampleDTO = this.hasUnannotatedItem 
+      const itemToAnnotate: undefined | ExampleDTO = this.hasUnannotatedItem
         ? this.item.items.find((item: any) => !item.isConfirmed)
         : this.item.items[0]
       const index = itemToAnnotate ? this.item.items.indexOf(itemToAnnotate) : 0
-      const page = ( index + 1).toString()
+      const page = (index + 1).toString()
       await this.startAnnotation()
       this.movePage({ page })
     },
     startAnnotation() {
-      const item = this.hasUnannotatedItem ? 
-        this.item.items.find((item: any) => !item.isConfirmed)
+      const item = this.hasUnannotatedItem
+        ? this.item.items.find((item: any) => !item.isConfirmed)
         : this.item.items[0]
-      if(item && !item.isConfirmed) {
+      if (item && !item.isConfirmed) {
         this.$services.example.annotateStartStates(this.projectId, item.id)
       }
     },
     async loadData() {
       this.isLoading = true
-      const query = {...this.$route.query, ...{
-        isChecked: this.isConfirmed
-      }}
+      const query = {
+        ...this.$route.query,
+        ...{
+          isChecked: this.isConfirmed
+        }
+      }
       this.item = await this.$services.example.list(this.projectId, query)
+
+      const limit = 100
+      const requests = this.item.items
+        .filter((item: any) => item.isConfirmed)
+        .map((item: any) => this.$services.example.listStates(this.projectId, item.id))
+        .splice(0, limit)
+      const promises = await Promise.all(requests)
+      const states = [..._.flatMap(promises, 'items')]
+
+      const todayStates = states.filter(
+        (state) =>
+          moment(new Date()).format(this.dateFormat) ===
+          moment(state.confirmedAt, this.serverDateFormat).format(this.dateFormat)
+      )
+
+      this.setAnnotation({
+        hasAnnotatedToday: !!todayStates.length,
+        lastAnnotationTime: todayStates.length
+          ? moment(todayStates[0].confirmedAt, this.serverDateFormat).format(this.savedDateFormat)
+          : '',
+        textCountToday: todayStates.length
+      })
+
       this.isLoading = false
     },
     async remove() {
@@ -287,7 +319,7 @@ export default Vue.extend({
         path: this.localePath(this.project.pageLink),
         query
       })
-    },
+    }
   }
 })
 </script>

--- a/frontend/pages/projects/_id/dataset/index.vue
+++ b/frontend/pages/projects/_id/dataset/index.vue
@@ -289,11 +289,19 @@ export default Vue.extend({
           moment(state.confirmedAt, this.serverDateFormat).format(this.dateFormat)
       )
 
+      const firstAnnotationTime = todayStates.length
+        ? moment(todayStates[0].confirmedAt, this.serverDateFormat).format(this.savedDateFormat)
+        : ''
+      const lastAnnotationTime = todayStates.length
+        ? moment(todayStates[todayStates.length - 1].confirmedAt, this.serverDateFormat).format(
+            this.savedDateFormat
+          )
+        : ''
+
       this.setAnnotation({
         hasAnnotatedToday: !!todayStates.length,
-        lastAnnotationTime: todayStates.length
-          ? moment(todayStates[0].confirmedAt, this.serverDateFormat).format(this.savedDateFormat)
-          : '',
+        firstAnnotationTime,
+        lastAnnotationTime,
         textCountToday: todayStates.length
       })
 

--- a/frontend/pages/projects/create.vue
+++ b/frontend/pages/projects/create.vue
@@ -56,23 +56,28 @@ export default Vue.extend({
     async create() {
       const projectItem = this.getProjectItem()
       const project = await this.$services.project.create(projectItem)
-      if(project.projectType === 'AffectiveAnnotation') {
+      if (project.projectType === 'AffectiveAnnotation') {
         if (!project.isSummaryMode) {
           await this.uploadScaleTypeFile(project)
         }
-      } 
+      }
       this.$router.push(this.localePath(`/projects/${project.id}`))
       this.$nextTick(() => {
         this.editedItem = Object.assign({}, this.defaultItem)
       })
     },
-    getProjectItem() : ProjectWriteDTO {
-      const editedItem : any = _.cloneDeep(this.editedItem)
-      if(this.editedItem.affectiveProjectMode) {
+    getProjectItem(): ProjectWriteDTO {
+      const editedItem: any = _.cloneDeep(this.editedItem)
+      if (this.editedItem.affectiveProjectMode) {
         editedItem[this.editedItem.affectiveProjectMode] = true
       }
-      const affectiveProjectModes = ['isHumorMode', 'isSummaryMode', 'isEmotionsMode',
-        'isOthersMode', 'isOffensiveMode']
+      const affectiveProjectModes = [
+        'isHumorMode',
+        'isSummaryMode',
+        'isEmotionsMode',
+        'isOthersMode',
+        'isOffensiveMode'
+      ]
       affectiveProjectModes.forEach((key: string) => {
         const mode = editedItem[key] || false
         editedItem[key] = this.editedItem.isCombinationMode ? false : mode
@@ -80,22 +85,22 @@ export default Vue.extend({
       delete editedItem.affectiveProjectMode
       return editedItem
     },
-    async getBlobScaleData(project: ProjectDTO) {
-      let fdata = []
-      if(project.isCombinationMode) {
+    async getBlobScaleData(project: ProjectDTO): Promise<Blob[]> {
+      let fdata = [] as Blob[]
+      if (project.isCombinationMode) {
         const paths = {
           isEmotionsMode: '/formats/affective_annotation/affective_emotions_scales.json',
           isOthersMode: '/formats/affective_annotation/affective_others_scales.json',
           isHumorMode: '/formats/affective_annotation/affective_humor_scales.json',
           isOffensiveMode: '/formats/affective_annotation/affective_offensive_scales.json'
         }
-        const requests = Object.values(paths).map((path)=> fetch(path))
+        const requests = Object.values(paths).map((path) => fetch(path))
         const responses = await Promise.all(requests)
         const blobPromises = responses.map(async (response) => await response.blob())
         const blobs = await Promise.all(blobPromises)
         return [...blobs.flat()]
       } else {
-        let selectedFile = ""
+        let selectedFile = ''
         if (project.isEmotionsMode) {
           selectedFile = '/formats/affective_annotation/affective_emotions_scales.json'
         }
@@ -114,10 +119,10 @@ export default Vue.extend({
       return fdata
     },
     async uploadScaleTypeFile(project: ProjectDTO) {
-      const fdatas : Blob[] = await this.getBlobScaleData(project)
-      fdatas.forEach(async (fdata, index)=> {
+      const fdatas: Blob[] = await this.getBlobScaleData(project)
+      fdatas.forEach(async (fdata, index) => {
         const fname = `scales_${index}.json`
-        const fmetadata = { type: "application/JSON" }
+        const fmetadata = { type: 'application/JSON' }
         const file = new File([fdata], fname, fmetadata)
         try {
           const projectId = project.id.toString()

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -42,6 +42,7 @@ import { ProjectDTO, ProjectListDTO } from '~/services/application/project/proje
 import FormDelete from '~/components/project/FormDelete.vue'
 
 export default Vue.extend({
+  name: 'Projects',
   components: {
     FormDelete,
     ProjectList,

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -160,7 +160,7 @@ export default Vue.extend({
       let firstQuestionnaireEverDate = null
       if (questionnaireStates && questionnaireStates.items.length > 0) {
         const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
-        firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+        firstQuestionnaireEverDate = moment(String(firstQuestionnaireEver)).format('DD-MM-YYYY')
       }
       this.initQuestionnaire(firstQuestionnaireEverDate)
       if (!this.isStaff && this.getQuestionnaire.toShow.length) {

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -157,8 +157,11 @@ export default Vue.extend({
         questionnaireTypeId: 1,
         limit: 1
       })
-      const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
-      const firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+      let firstQuestionnaireEverDate = null
+      if (questionnaireStates) {
+        const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
+        firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+      }
       this.initQuestionnaire(firstQuestionnaireEverDate)
       if (!this.isStaff && this.getQuestionnaire.toShow.length) {
         this.$router.push(this.localePath('/questionnaires'))

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -158,7 +158,7 @@ export default Vue.extend({
         limit: 1
       })
       let firstQuestionnaireEverDate = null
-      if (questionnaireStates) {
+      if (questionnaireStates && questionnaireStates.items.length > 0) {
         const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
         firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
       }

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -33,6 +33,7 @@
 
 <script lang="ts">
 import _ from 'lodash'
+import moment from 'moment'
 import Vue from 'vue'
 import { mapGetters, mapActions } from 'vuex'
 import ProjectList from '@/components/project/ProjectList.vue'
@@ -147,12 +148,18 @@ export default Vue.extend({
       }
       const hasFinishedAll = this.projects.items.length === 0
       this.setProject({ hasFinishedAll })
-      this.checkQuestionnaire()
+      await this.checkQuestionnaire()
       this.isLoading = false
     },
 
-    checkQuestionnaire() {
-      this.initQuestionnaire()
+    async checkQuestionnaire() {
+      const questionnaireStates = await this.$services.questionnaire.listFinishedQuestionnaires({
+        questionnaireTypeId: 1,
+        limit: 1
+      })
+      const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
+      const firstQuestionnaireEverDate = moment(firstQuestionnaireEver).format('DD-MM-YYYY')
+      this.initQuestionnaire(firstQuestionnaireEverDate)
       if (!this.isStaff && this.getQuestionnaire.toShow.length) {
         this.$router.push(this.localePath('/questionnaires'))
       }

--- a/frontend/pages/questionnaires/codziennie_w_trakcie/js/questionnaires.js
+++ b/frontend/pages/questionnaires/codziennie_w_trakcie/js/questionnaires.js
@@ -6,6 +6,7 @@ export const qTypes = [
             {
                 name: "Sen (rano)",
                 language: "pl",
+                typeId: "4.1",
                 segments: [
                     {
                         scales: {
@@ -62,6 +63,7 @@ export const qTypes = [
             {
                 name: "Stres (rano)",
                 language: "pl",
+                typeId: "4.1",
                 segments: [
                     {
                         description: "Poniżej podano kilka stwierdzeń, z którymi możesz się zgadzać lub nie. Używając skali 0 do 4 wskaż, w jakim stopniu zgadzasz się z każdym stwierdzeniem. Bądź szczery w swoich odpowiedziach.",
@@ -117,6 +119,7 @@ export const qTypes = [
             {
                 name: "Stres (wieczorem)",
                 language: "pl",
+                typeId: "4.2",
                 segments: [
                     {
                         scales: {
@@ -166,6 +169,7 @@ export const qTypes = [
             {
                 name: "Zdrowie (wieczorem)",
                 language: "pl",
+                typeId: "4.2",
                 segments: [
                     {
                         scales: {
@@ -207,12 +211,13 @@ export const qTypes = [
         ]
     },
     {
-        name: "W przerwie (emocje)",
+        name: "Emocje (w przerwie)",
         id: "4.3",
         questionnaires: [
             {
                 name: "Emocje (w przerwie)",
                 language: "pl",
+                typeId: "4.3",
                 segments: [
                     {
                         questions: [

--- a/frontend/pages/questionnaires/na_koniec/js/questionnaires.js
+++ b/frontend/pages/questionnaires/na_koniec/js/questionnaires.js
@@ -6,6 +6,7 @@ export const qTypes = [
             {
                 name: "Ankieta na koniec badania",
                 language: "pl",
+                typeId: "5.1",
                 segments: [
                     {
                         questions: [

--- a/frontend/pages/questionnaires/po_1_tygodniu_i_na_koncu/js/questionnaires.js
+++ b/frontend/pages/questionnaires/po_1_tygodniu_i_na_koncu/js/questionnaires.js
@@ -6,6 +6,7 @@ export const qTypes = [
             {
                 name: "Ankieta zwrotna",
                 language: "pl",
+                typeId: "3.1",
                 type: "ankieta zwrotna",
                 description: "Celem ankiety jest zebranie informacji zwrotnej dotyczącej przeprowadzanego badania po to, aby móc ulepszyć procedury w przyszłości.",
                 segments: [
@@ -36,6 +37,7 @@ export const qTypes = [
             {
                 name: "Ankieta zwrotna",
                 language: "pl",
+                typeId: "3.2",
                 type: "ankieta zwrotna",
                 description: "Celem ankiety jest zebranie informacji zwrotnej dotyczącej przeprowadzanego badania po to, aby móc ulepszyć procedury w przyszłości.",
                 segments: [

--- a/frontend/pages/questionnaires/po_2_tygodniach/js/questionnaires.js
+++ b/frontend/pages/questionnaires/po_2_tygodniach/js/questionnaires.js
@@ -6,6 +6,7 @@ export const qTypes = [
             {
                 name: "Ankieta po 2 tygodniach badania",
                 language: "pl",
+                typeId: "6.1",
                 segments: [
                     {
                         scales: {

--- a/frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js
+++ b/frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js
@@ -6,6 +6,7 @@ export const qTypes = [
             {
                 name: "Kwestionariusz IPIP-BFM-20",
                 language: "pl",
+                typeId: "1.1",
                 type: "osobowość",
                 description: "Przeczytaj uważnie poniższe zdania, opisujące różne zachowania, uczucia i myśli ludzi. Zastanów się nad każdym z nich – w jakim stopniu opisuje ono również Ciebie takiego/taką, jakim/jaką zwykle jesteś? Ludzie są bardzo różni, więc nie ma tu dobrych ani złych odpowiedzi. Za każdym razem po prostu szczerze odpowiedz na pytanie, w jakim stopniu dane stwierdzenie opisuje Ciebie.",
                 segments: [
@@ -183,6 +184,7 @@ export const qTypes = [
             {
                 name: "Demografia",
                 type: "demografia",
+                typeId: "1.1",
                 language: "pl",
                 segments: [
                     {
@@ -528,6 +530,7 @@ export const qTypes = [
             {
                 type: "humor",
                 name: "Humor Styles Questionnaire",
+                typeId: "1.1",
                 language: "pl",
                 segments: [
                     {

--- a/frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js
+++ b/frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js
@@ -485,9 +485,17 @@ export const qTypes = [
                                 options: [
                                     {
                                         text: "Lewicowe (rozwinięty interwencjonizm państwowy, wysokie podatki, wyższe podatki dla bogatszych, rozwinięta polityka socjalna)",
+                                        showSlider: true,
+                                        min: 1,
+                                        max: 10,
+                                        showTickLabels: true
                                     },
                                     {
                                         text: "Prawicowe (dominacja własności prywatnej, ograniczenie interwencjonizmu państwowego, niskie podatki, ograniczone ramy polityki socjalnej państwa)",
+                                        showSlider: true,
+                                        min: 1,
+                                        max: 10,
+                                        showTickLabels: true
                                     }
                                 ]
                             },
@@ -497,9 +505,18 @@ export const qTypes = [
                                 options: [
                                     {
                                         text: "Liberalne (akceptacja związków homoseksualnych, transseksualizmu, aborcji, egalitarność)",
+                                        showSlider: true,
+                                        min: 1,
+                                        max: 10,
+                                        showTickLabels: true
                                     },
                                     {
                                         text: "Konserwatywne (ważne wartości to rodzina, naród, tradycja, hierarchia społeczna)",
+                                        showSlider: true,
+                                        min: 1,
+                                        max: 10,
+                                        showTickLabels: true
+
                                     }
                                 ]
                             }

--- a/frontend/pages/questionnaires/przed_i_po_badaniu/js/questionnaires.js
+++ b/frontend/pages/questionnaires/przed_i_po_badaniu/js/questionnaires.js
@@ -6,6 +6,7 @@ export const qTypes = [
             {
                 name: "SWLS-A",
                 language: "pl",
+                typeId: "2.1",
                 type: "dobrostan: satysfakcja z życia",
                 segments: [
                     {
@@ -84,6 +85,7 @@ export const qTypes = [
             },
             {
                 name: "SPANE",
+                typeId: "2.1",
                 language: "pl",
                 type: "dobrostan: afekt",
                 segments: [
@@ -204,6 +206,7 @@ export const qTypes = [
             },
             {
                 name: "Skala Prosperowania",
+                typeId: "2.1",
                 language: "pl",
                 type: "dobrostan: skala prosperowania",
                 segments: [
@@ -304,6 +307,7 @@ export const qTypes = [
             },
             {
                 name: "Kwestionariusz Zdrowia Pacjenta PHQ-9 (PHQ-9)",
+                typeId: "2.1",
                 language: "pl",
                 type: "depresja",
                 segments: [
@@ -399,6 +403,7 @@ export const qTypes = [
             },
             {
                 name: "Kwestionariusz PSS",
+                typeId: "2.1",
                 language: "pl",
                 type: "stres",
                 segments: [
@@ -505,6 +510,7 @@ export const qTypes = [
             },
             {
                 name: "Physical Health Questionnaire",
+                typeId: "2.1",
                 language: "pl",
                 type: "zdrowie",
                 segments: [
@@ -688,6 +694,7 @@ export const qTypes = [
             },
             {
                 name: "List of RESS-EMA Items",
+                typeId: "2.1",
                 language: "pl",
                 type: "regulacja emocji",
                 segments: [
@@ -833,6 +840,7 @@ export const qTypes = [
             {
                 name: "PAQ",
                 language: "pl",
+                typeId: "2.1",
                 type: "alexytymia",
                 segments: [
                     {
@@ -924,6 +932,7 @@ export const qTypes = [
         questionnaires: [
             {
                 name: "SWLS-A",
+                typeId: "2.2",
                 language: "pl",
                 type: "dobrostan: satysfakcja z życia",
                 segments: [
@@ -1004,6 +1013,7 @@ export const qTypes = [
             {
                 name: "SPANE",
                 language: "pl",
+                typeId: "2.2",
                 type: "dobrostan: afekt",
                 segments: [
                     {
@@ -1124,6 +1134,7 @@ export const qTypes = [
             {
                 name: "Skala Prosperowania",
                 language: "pl",
+                typeId: "2.2",
                 type: "dobrostan: skala prosperowania",
                 segments: [
                     {
@@ -1224,6 +1235,7 @@ export const qTypes = [
             {
                 name: "Kwestionariusz Zdrowia Pacjenta PHQ-9 (PHQ-9)",
                 language: "pl",
+                typeId: "2.2",
                 type: "depresja",
                 segments: [
                     {
@@ -1319,6 +1331,7 @@ export const qTypes = [
             {
                 name: "Kwestionariusz PSS",
                 language: "pl",
+                typeId: "2.2",
                 type: "stres",
                 segments: [
                     {
@@ -1425,6 +1438,7 @@ export const qTypes = [
             {
                 name: "Physical Health Questionnaire",
                 language: "pl",
+                typeId: "2.2",
                 type: "zdrowie",
                 segments: [
                     {
@@ -1608,6 +1622,7 @@ export const qTypes = [
             {
                 name: "List of RESS-EMA Items",
                 language: "pl",
+                typeId: "2.2",
                 type: "regulacja emocji",
                 segments: [
                     {
@@ -1752,6 +1767,7 @@ export const qTypes = [
             {
                 name: "PAQ",
                 language: "pl",
+                typeId: "2.2",
                 type: "alexytymia",
                 segments: [
                     {

--- a/frontend/repositories/example/apiDocumentRepository.ts
+++ b/frontend/repositories/example/apiDocumentRepository.ts
@@ -1,7 +1,7 @@
 import { plainToInstance } from 'class-transformer'
 import ApiService from '@/services/api.service'
 import { ExampleRepository, SearchOption } from '~/domain/models/example/exampleRepository'
-import { ExampleItem, ExampleItemList } from '~/domain/models/example/example'
+import { ExampleItem, ExampleItemList, ExampleStateItemList } from '~/domain/models/example/example'
 
 export class APIExampleRepository implements ExampleRepository {
   constructor(private readonly request = ApiService) {}
@@ -47,6 +47,12 @@ export class APIExampleRepository implements ExampleRepository {
     const url = `/projects/${projectId}/examples/${exampleId}`
     const response = await this.request.get(url)
     return plainToInstance(ExampleItem, response.data)
+  }
+
+  async listStates(projectId: string, exampleId: number): Promise<ExampleStateItemList> {
+    const url = `/projects/${projectId}/examples/${exampleId}/states`
+    const response = await this.request.get(url)
+    return plainToInstance(ExampleStateItemList, response.data)
   }
 
   async confirm(projectId: string, exampleId: number): Promise<void> {

--- a/frontend/repositories/questionnaire/apiQuestionnaireRepository.ts
+++ b/frontend/repositories/questionnaire/apiQuestionnaireRepository.ts
@@ -1,7 +1,11 @@
 import { plainToInstance } from 'class-transformer'
 import ApiService from '@/services/api.service'
 import { QuestionnaireRepository, SearchOption } from '~/domain/models/questionnaire/questionnaireRepository'
-import { QuestionnaireTypeItemList, QuestionnaireItemList, QuestionItemList, AnswerReadItem, AnswerWriteItem } 
+import { QuestionnaireTypeItemList, QuestionnaireItemList, QuestionItemList, 
+  AnswerReadItem, 
+  AnswerWriteItem, 
+  QuestionnaireTimeItem,
+  QuestionnaireTimeItemList } 
 from "~/domain/models/questionnaire/questionnaire"
 
 export class APIQuestionnaireRepository implements QuestionnaireRepository {
@@ -26,6 +30,19 @@ export class APIQuestionnaireRepository implements QuestionnaireRepository {
     const response = await this.request.get(url)
     return plainToInstance(QuestionItemList, response.data)
   }
+
+  async listFinishedQuestionnaires({ limit = '10', offset = '0', q = '' }: SearchOption): 
+  Promise<QuestionnaireTimeItemList> {
+  const url = `/questionnaire_filled_progress?limit=${limit}&offset=${offset}&q=${q}`
+  const response = await this.request.get(url)
+  return plainToInstance(QuestionnaireTimeItemList, response.data)
+}
+
+async createQuestionnaireFinishedState(questionnaireId : number): Promise<QuestionnaireTimeItem> {
+  const url = `/questionnaire_states/${questionnaireId}`
+  const response = await this.request.post(url)
+  return plainToInstance(QuestionnaireTimeItem, response.data)
+}
 
   async createAnswer(item: AnswerWriteItem): Promise<AnswerReadItem> {
     const url = `/answers/${item.question}`

--- a/frontend/services/application/example/exampleApplicationService.ts
+++ b/frontend/services/application/example/exampleApplicationService.ts
@@ -1,5 +1,5 @@
 import { plainToInstance } from 'class-transformer'
-import { ExampleDTO, ExampleListDTO } from './exampleData'
+import { ExampleDTO, ExampleListDTO, ExampleStateListDTO } from './exampleData'
 import { ExampleRepository, SearchOption } from '~/domain/models/example/exampleRepository'
 import { ExampleItem } from '~/domain/models/example/example'
 
@@ -90,6 +90,15 @@ export class ExampleApplicationService {
 
   public async annotateStartStates(projectId: string, exampleId: number): Promise<void> {
     await this.repository.annotateStartStates(projectId, exampleId)
+  }
+
+  public async listStates(projectId: string, exampleId: number): Promise<ExampleStateListDTO> {
+    try {
+      const item = await this.repository.listStates(projectId, exampleId)
+      return new ExampleStateListDTO(item)
+    } catch (e: any) {
+      throw new Error(e.response.data.detail)
+    }
   }
 
   private toModel(item: ExampleDTO): ExampleItem {

--- a/frontend/services/application/example/exampleData.ts
+++ b/frontend/services/application/example/exampleData.ts
@@ -1,9 +1,23 @@
 import { Expose } from 'class-transformer'
-import { ExampleItem, ExampleMetaItem, ExampleItemList } from '~/domain/models/example/example'
+import { ExampleItem,ExampleStateItem, ExampleStateItemList, ExampleMetaItem, ExampleItemList } from '~/domain/models/example/example'
 
 export class ExampleMetadataDTO {
   key: string
   value: string
+}
+
+export class ExampleStateDTO {
+  id: number
+  example: number
+  confirmedAt: String
+  confirmedBy: number
+
+  constructor(item: ExampleStateItem) {
+    this.id = item.id
+    this.example = item.example
+    this.confirmedAt = item.confirmedAt
+    this.confirmedBy = item.confirmedBy
+  }
 }
 
 export class ExampleDTO {
@@ -55,6 +69,21 @@ export class ExampleArticleDTO {
   @Expose({ name: 'publish_datetime' })
   publishDatetime: string 
 }
+
+export class ExampleStateListDTO {
+  count: number
+  next: string | null
+  prev: string | null
+  items: ExampleStateDTO[]
+
+  constructor(item: ExampleStateItemList) {
+    this.count = item.count
+    this.next = item.next
+    this.prev = item.prev
+    this.items = item.items.map((_) => new ExampleStateDTO(_))
+  }
+}
+
 
 export class ExampleListDTO {
   count: number

--- a/frontend/services/application/questionnaire/questionnaireApplicationService.ts
+++ b/frontend/services/application/questionnaire/questionnaireApplicationService.ts
@@ -1,6 +1,7 @@
-import { QuestionnaireListDTO, QuestionListDTO, QuestionnaireTypeListDTO, AnswerWriteDTO, AnswerReadDTO } from './questionnaireData'
+import { QuestionnaireListDTO, QuestionListDTO, QuestionnaireTypeListDTO, AnswerWriteDTO, AnswerReadDTO,
+  QuestionnaireTimeItemDTO, QuestionnaireTimeItemListDTO } from './questionnaireData'
 import { QuestionnaireRepository, SearchOption } from '~/domain/models/questionnaire/questionnaireRepository'
-import { AnswerWriteItem } from '~/domain/models/questionnaire/questionnaire'
+import { AnswerWriteItem, QuestionnaireTimeItem, QuestionnaireTimeItemList } from '~/domain/models/questionnaire/questionnaire'
 
 export class QuestionnaireApplicationService {
   constructor(private readonly repository: QuestionnaireRepository) {}
@@ -32,6 +33,15 @@ export class QuestionnaireApplicationService {
     }
   }
 
+  public async listFinishedQuestionnaires(options: SearchOption): Promise<QuestionnaireTimeItemList> {
+    try {
+      const items = await this.repository.listFinishedQuestionnaires(options)
+      return new QuestionnaireTimeItemListDTO(items)
+    } catch (e: any) {
+      throw new Error(e.response.data.detail)
+    }
+  }
+
   public async createAnswer(item: AnswerWriteDTO): Promise<AnswerReadDTO> {
     try {
       const answer = this.toWriteModel(item)
@@ -51,6 +61,16 @@ export class QuestionnaireApplicationService {
       throw new Error(e.response.data.detail)
     }
   }
+
+  public async createQuestionnaireFinishedState(questionnaireId: number): Promise<QuestionnaireTimeItem> {
+    try {
+      const response = await this.repository.createQuestionnaireFinishedState(questionnaireId)
+      return new QuestionnaireTimeItemDTO(response)
+    } catch (e: any) {
+      throw new Error(e.response.data.detail)
+    }
+  }
+
 
   private toWriteModel(item: AnswerWriteDTO): AnswerWriteItem {
     return new AnswerWriteItem(

--- a/frontend/services/application/questionnaire/questionnaireData.ts
+++ b/frontend/services/application/questionnaire/questionnaireData.ts
@@ -1,4 +1,7 @@
-import { AnswerReadItem, AnswerWriteItem,  QuestionItem, QuestionItemList, QuestionnaireItem, QuestionnaireItemList, QuestionnaireTypeItem, QuestionnaireTypeItemList } from '~/domain/models/questionnaire/questionnaire'
+import { AnswerReadItem, AnswerWriteItem,  
+  QuestionItem, QuestionItemList, QuestionnaireItem, 
+  QuestionnaireItemList, QuestionnaireTimeItem, QuestionnaireTimeItemList, 
+  QuestionnaireTypeItem, QuestionnaireTypeItemList } from '~/domain/models/questionnaire/questionnaire'
 
 
 export class QuestionnaireTypeDTO {
@@ -55,6 +58,20 @@ export class AnswerReadDTO {
     }
 }
 
+export class QuestionnaireTimeItemDTO {
+  id: number
+  questionnaire: number
+  finishedBy: number
+  finishedAt: String
+
+  constructor(item: QuestionnaireTimeItem) {
+    this.id = item.id
+    this.questionnaire = item.questionnaire
+    this.finishedBy = item.finishedBy
+    this.finishedAt = item.finishedAt
+  }
+}
+  
 export type AnswerWriteDTO = Pick<
 AnswerWriteItem,
   | 'id'
@@ -74,6 +91,20 @@ export class QuestionnaireTypeListDTO {
       this.next = item.next
       this.previous = item.previous
       this.items = item.items.map((_) => new QuestionnaireTypeDTO(_))
+    }
+  }
+  
+  export class QuestionnaireTimeItemListDTO {
+    count: number
+    next: string | null
+    previous: string | null
+    items: QuestionnaireTimeItemDTO[]
+  
+    constructor(item: QuestionnaireTimeItemList) {
+      this.count = item.count
+      this.next = item.next
+      this.previous = item.previous
+      this.items = item.items.map((_) => new QuestionnaireTimeItemDTO(_))
     }
   }
   

--- a/frontend/store/user.js
+++ b/frontend/store/user.js
@@ -172,9 +172,9 @@ export const actions = {
     const endTime = moment(startTime).add(5, 'm').format('DD-MM-YYYY HH:mm:ss')
     commit('setRestingPeriod', endTime)
   },
-  initQuestionnaire({commit}) {
+  initQuestionnaire({commit}, firstQuestionnaireEverDate) {
     if(hasStore()) {
-      const toShow = getQuestionnairesToShow()
+      const toShow = getQuestionnairesToShow(firstQuestionnaireEverDate)
       commit('setQuestionnaire', { toShow, inProgress: [], isWorkingNow: false })
     }
   },

--- a/frontend/store/user.js
+++ b/frontend/store/user.js
@@ -27,6 +27,7 @@ export const history =
   annotation: {
     textCountToday: 0,
     hasAnnotatedToday: false,
+    firstAnnotationTime: "",
     lastAnnotationTime: "",
   },
   questionnaire: {

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -318,6 +318,7 @@ export function hasValidLoginTime(givenTime) {
 }
 
 export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
+    console.log(firstQuestionnaireEverStr)
     const qTypes = getQuestionnaireTypes()
     const todayTime = new Date()
     let getters = null
@@ -335,7 +336,10 @@ export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const { firstLoginTime } = getters['user/getLogin']
                 const { firstAnnotationTime } = getters['user/getAnnotation']
-                const firstQuestionnaireEverDate = moment(firstQuestionnaireEverStr, 'DD-MM-YYYY').toDate()
+                let firstQuestionnaireEverDate = new Date()
+                if (firstQuestionnaireEverStr) {
+                    firstQuestionnaireEverDate = moment(firstQuestionnaireEverStr, 'DD-MM-YYYY').toDate()
+                }
                 const firstLoginTimeAtZero = moment(firstLoginTime, DATE_FORMAT).format("DD-MM-YYYY")+" 00:00:00"
                 const { hasAnnotatedToday, textCountToday } = getters['user/getAnnotation']
                 const defaultTime = firstAnnotationTime || firstLoginTimeAtZero
@@ -356,6 +360,9 @@ export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
                     isShowing = !isFilled
                 } else if(questionnaireType.id === "2.2") {
                     isShowing = !isFilled && hasPassedResearchTime
+                    console.log("todayTime", todayTime)
+                    console.log("hasPassedResearchTime", hasPassedResearchTime)
+                    console.log("2.2 isShowing: ", isShowing)
                 } else if(questionnaireType.id === "3.1") {
                     const weekDiff = Math.abs(moment(todayTime)
                                     .diff(moment(defaultTime, DATE_FORMAT), 'weeks'))
@@ -363,6 +370,9 @@ export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
                     isShowing = !isFilled && hasPassedOneWeek
                 } else if(questionnaireType.id === "3.2") {
                     isShowing = !isFilled && hasPassedResearchTime
+                    console.log("todayTime", todayTime)
+                    console.log("hasPassedResearchTime", hasPassedResearchTime)
+                    console.log("3.2 isShowing: ", isShowing)
                 } else if(questionnaireType.id === "4.1") {
                     isShowing = !isFilled && !hasAnnotatedToday
                 }  else if(questionnaireType.id === "4.2") {
@@ -377,6 +387,9 @@ export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
                     isShowing = !isFilled && hasAnnotatedBatch
                 } else if(questionnaireType.id === "5.1") {
                     isShowing = !isFilled && hasPassedResearchTime
+                    console.log("todayTime", todayTime)
+                    console.log("hasPassedResearchTime", hasPassedResearchTime)
+                    console.log("5.1 isShowing: ", isShowing)
                 } else if(questionnaireType.id === "6.1") {
                     const weekDiff = Math.abs(moment(todayTime)
                                     .diff(moment(defaultTime, DATE_FORMAT), 'weeks'))

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -176,6 +176,12 @@ export function setQuestionnaireIds(qTypes, questionnaires=[], questions=[], que
                             que.isFinishedToday = que.isFinished
                         }
                     }
+                    if(state && que.typeId === "2.2") {
+                        que.isFinished = states.length > 1
+                    }
+                    if(state && que.typeId === "3.2") {
+                        que.isFinished = states.length > 1
+                    }
                 }
                 que.segments = que.segments.map((segment)=> {
                     segment.questions = segment.questions.map((question)=> {
@@ -331,8 +337,9 @@ export function getQuestionnairesToShow() {
                 const { firstAnnotationTime } = getters['user/getAnnotation']
                 const firstLoginTimeAtZero = moment(firstLoginTime, DATE_FORMAT).format("DD-MM-YYYY")+" 00:00:00"
                 const { hasAnnotatedToday, textCountToday } = getters['user/getAnnotation']
+                const defaultTime = firstAnnotationTime || firstLoginTimeAtZero
                 const monthDiff = Math.abs(moment(todayTime).diff(
-                    moment(firstLoginTimeAtZero, DATE_FORMAT), 'months'
+                    moment(defaultTime, DATE_FORMAT), 'months'
                 ))
                 const hasPassedResearchTime = monthDiff >= RESEARCH_TIME_IN_MONTHS
                 let isShowing = false
@@ -346,9 +353,8 @@ export function getQuestionnairesToShow() {
                 } else if(questionnaireType.id === "2.2") {
                     isShowing = !isFilled && hasPassedResearchTime
                 } else if(questionnaireType.id === "3.1") {
-                    const time = firstAnnotationTime ?? firstLoginTimeAtZero
                     const weekDiff = Math.abs(moment(todayTime)
-                                    .diff(moment(time, DATE_FORMAT), 'weeks'))
+                                    .diff(moment(defaultTime, DATE_FORMAT), 'weeks'))
                     const hasPassedOneWeek = weekDiff >= 1
                     isShowing = !isFilled && hasPassedOneWeek
                 } else if(questionnaireType.id === "3.2") {
@@ -368,9 +374,8 @@ export function getQuestionnairesToShow() {
                 } else if(questionnaireType.id === "5.1") {
                     isShowing = !isFilled && hasPassedResearchTime
                 } else if(questionnaireType.id === "6.1") {
-                    const time = firstAnnotationTime ?? firstLoginTimeAtZero
                     const weekDiff = Math.abs(moment(todayTime)
-                                    .diff(moment(time, DATE_FORMAT), 'weeks'))
+                                    .diff(moment(defaultTime, DATE_FORMAT), 'weeks'))
                     const hasPassedTwoWeeks = weekDiff >= 2
                     isShowing = !isFilled && hasPassedTwoWeeks
                 }

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -303,9 +303,9 @@ export function hasValidLoginTime(givenTime) {
     }
     if(getters) {
         const { lastLoginTime } = getters['user/getLogin']
-        const diffTime = moment(givenTime).diff(
+        const diffTime = Math.abs(moment(givenTime).diff(
             moment(lastLoginTime, DATE_FORMAT), 'days'
-        )
+        ))
         hasValidLoginTime = diffTime >= 0
     }
     return hasValidLoginTime
@@ -330,14 +330,14 @@ export function getQuestionnairesToShow() {
                 const { firstLoginTime } = getters['user/getLogin']
                 const firstLoginTimeAtZero = moment(firstLoginTime, DATE_FORMAT).format("DD-MM-YYYY")+" 00:00:00"
                 const { hasAnnotatedToday, textCountToday } = getters['user/getAnnotation']
-                const monthDiff = moment(todayTime).diff(
+                const monthDiff = Math.abs(moment(todayTime).diff(
                     moment(firstLoginTimeAtZero, DATE_FORMAT), 'months'
-                )
+                ))
                 const hasPassedResearchTime = monthDiff >= RESEARCH_TIME_IN_MONTHS
                 let isShowing = false
                 if(questionnaireType.id === '1.1') {
-                    const hourDiff = moment(firstLoginTime, DATE_FORMAT)
-                                        .diff(moment(todayTime), 'hours')
+                    const hourDiff = Math.abs(moment(firstLoginTime, DATE_FORMAT)
+                                        .diff(moment(todayTime), 'hours'))
                     const isFirstSignIn = hourDiff < .5
                     isShowing = !isFilled && isFirstSignIn
                 } else if(questionnaireType.id === "2.1") {
@@ -345,8 +345,8 @@ export function getQuestionnairesToShow() {
                 } else if(questionnaireType.id === "2.2") {
                     isShowing = !isFilled && hasPassedResearchTime
                 } else if(questionnaireType.id === "3.1") {
-                    const weekDiff = moment(todayTime)
-                                    .diff(moment(firstLoginTimeAtZero, DATE_FORMAT), 'weeks')
+                    const weekDiff = Math.abs(moment(todayTime)
+                                    .diff(moment(firstLoginTimeAtZero, DATE_FORMAT), 'weeks'))
                     const hasPassedOneWeek = weekDiff >= 1
                     isShowing = !isFilled && hasPassedOneWeek
                 } else if(questionnaireType.id === "3.2") {
@@ -366,8 +366,8 @@ export function getQuestionnairesToShow() {
                 } else if(questionnaireType.id === "5.1") {
                     isShowing = !isFilled && hasPassedResearchTime
                 } else if(questionnaireType.id === "6.1") {
-                    const weekDiff = moment(todayTime)
-                                    .diff(moment(firstLoginTimeAtZero, DATE_FORMAT), 'weeks')
+                    const weekDiff = Math.abs(moment(todayTime)
+                                    .diff(moment(firstLoginTimeAtZero, DATE_FORMAT), 'weeks'))
                     const hasPassedTwoWeeks = weekDiff >= 2
                     isShowing = !isFilled && hasPassedTwoWeeks
                 }

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -38,6 +38,7 @@ export const qCategories = [
                 id: "1.1",
                 name: "Przed badaniem",
                 count: 3,
+                questionnaires: [1, 2, 3]
             }
         ]
     },
@@ -50,11 +51,13 @@ export const qCategories = [
                 id: "2.1",
                 name: "Przed i po badaniu (przed badaniem)",
                 count: 8,
+                questionnaires: [4, 5, 6, 7, 8, 9, 10, 11]
             },
             {
                 id: "2.2",
                 name: "Przed i po badaniu (po badaniu)",
                 count: 8,
+                questionnaires: [4, 5, 6, 7, 8, 9, 10, 11]
             }
         ]
     },
@@ -66,12 +69,14 @@ export const qCategories = [
             {
                 id: "3.1",
                 name: "Po pierwszym tygodniu",
-                count: 1
+                count: 1, 
+                questionnaires: [12]
             },
             {
                 id: "3.2",
                 name: "Na końcu badań",
-                count: 1
+                count: 1,
+                questionnaires: [12]
             }
         ]
     }, 
@@ -82,18 +87,22 @@ export const qCategories = [
         types: [
             {
                 id: "4.1",
-                name: "Rano (sen, stres)",
+                name: "Sen (rano)",
+                description: "Rano (sen, stres)",
                 count: 2,
+                questionnaires: [13, 14]
             },
             {
                 id: "4.2",
                 name: "Wieczorem (stres, zdrowie)",
-                count: 2
+                count: 2, 
+                questionnaires: [15, 16]
             },
             {
                 id: "4.3",
                 name: "W przerwie (emocje)",
-                count: 1
+                questionnaires: [17],
+                count: 1,
             },
         ]
     },
@@ -106,6 +115,7 @@ export const qCategories = [
                 id: "5.1",
                 name: "Ankieta na koniec badania",
                 count: 1,
+                questionnaires: [18]
             }
         ]
     },
@@ -118,6 +128,7 @@ export const qCategories = [
                 id: "6.1",
                 name: "Ankieta po 2 tygodniach badania",
                 count: 1,
+                questionnaires: [19]
             }
         ]
     }

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -141,8 +141,8 @@ export function hasStore() {
 export function setQuestionnaireIds(qTypes, questionnaires=[], questions=[], questionnaireStates=[]) {
     return qTypes.map((qType)=> {
         if(qType && qType.questionnaires) {
-            qType.questionnaires = qType.questionnaires.map((que)=> {
-                const questionnaire = questionnaires.find((q)=> q.name === que.name)
+            qType.questionnaires = qType.questionnaires.map((que, queIdx)=> {
+                const questionnaire = questionnaires.find((q, qIdx)=> q.name === que.name || queIdx === qIdx)
                 if(questionnaire) {
                     que.id = questionnaire.id
                     que.type = questionnaire.questionnaireType

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -127,13 +127,15 @@ export function hasStore() {
     return !!window.$nuxt && !!window.$nuxt.$store
 }
 
-export function setQuestionnaireIds(qTypes, questionnaires, questions=[]) {
+export function setQuestionnaireIds(qTypes, questionnaires=[], questions=[], questionnaireStates=[]) {
     return qTypes.map((qType)=> {
         if(qType && qType.questionnaires) {
             qType.questionnaires = qType.questionnaires.map((que)=> {
-                const queId = questionnaires.find((q)=> q.name === que.name)
-                if(queId) {
-                    que.id = queId
+                const questionnaire = questionnaires.find((q)=> q.name === que.name)
+                if(questionnaire) {
+                    que.id = questionnaire.id
+                    que.type = questionnaire.questionnaireType
+                    que.isFinished = !!questionnaireStates.find((qs)=> qs.questionnaire === que.id)
                 }
                 que.segments = que.segments.map((segment)=> {
                     segment.questions = segment.questions.map((question)=> {

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -346,9 +346,9 @@ export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
                     moment(firstLoginTimeAtZero, DATE_FORMAT), 'months'
                 ))
                 const monthDiff2 = Math.abs(moment(todayTime).diff(
-                    moment(firstQuestionnaireEverDate, DATE_FORMAT), 'months'
+                    moment(firstQuestionnaireEverDate), 'months'
                 ))
-                const hasPassedResearchTime = monthDiff1 >= RESEARCH_TIME_IN_MONTHS || monthDiff2 >= RESEARCH_TIME_IN_MONTHS
+                const hasPassedResearchTime = monthDiff2 >= RESEARCH_TIME_IN_MONTHS || monthDiff1 >= RESEARCH_TIME_IN_MONTHS
                 let isShowing = false
                 if(questionnaireType.id === '1.1') {
                     const hourDiff = Math.abs(moment(firstLoginTime, DATE_FORMAT)

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -193,6 +193,17 @@ export function mapQuestionnaireTypes(qTypes) {
                                 option.config = { numericOnly: !!option.numericOnly }
                             }
 
+
+                            if(option.showSlider) {
+                                option.config = {
+                                    min: option.min ?? 0,
+                                    max: option.max ?? 0,
+                                    minLabel: option.minLabel ?? "",
+                                    maxLabel: option.maxLabel ?? "",
+                                    showTickLabels: option.showTickLabels ?? true
+                                }
+                            }
+
                             return option
                         })
                     }

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -317,7 +317,7 @@ export function hasValidLoginTime(givenTime) {
     return hasValidLoginTime
 }
 
-export function getQuestionnairesToShow() {
+export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
     const qTypes = getQuestionnaireTypes()
     const todayTime = new Date()
     let getters = null
@@ -335,13 +335,17 @@ export function getQuestionnairesToShow() {
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const { firstLoginTime } = getters['user/getLogin']
                 const { firstAnnotationTime } = getters['user/getAnnotation']
+                const firstQuestionnaireEverDate = moment(firstQuestionnaireEverStr, 'DD-MM-YYYY').toDate()
                 const firstLoginTimeAtZero = moment(firstLoginTime, DATE_FORMAT).format("DD-MM-YYYY")+" 00:00:00"
                 const { hasAnnotatedToday, textCountToday } = getters['user/getAnnotation']
                 const defaultTime = firstAnnotationTime || firstLoginTimeAtZero
-                const monthDiff = Math.abs(moment(todayTime).diff(
-                    moment(defaultTime, DATE_FORMAT), 'months'
+                const monthDiff1 = Math.abs(moment(todayTime).diff(
+                    moment(firstLoginTimeAtZero, DATE_FORMAT), 'months'
                 ))
-                const hasPassedResearchTime = monthDiff >= RESEARCH_TIME_IN_MONTHS
+                const monthDiff2 = Math.abs(moment(todayTime).diff(
+                    moment(firstQuestionnaireEverDate, DATE_FORMAT), 'months'
+                ))
+                const hasPassedResearchTime = monthDiff1 >= RESEARCH_TIME_IN_MONTHS || monthDiff2 >= RESEARCH_TIME_IN_MONTHS
                 let isShowing = false
                 if(questionnaireType.id === '1.1') {
                     const hourDiff = Math.abs(moment(firstLoginTime, DATE_FORMAT)

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -328,6 +328,7 @@ export function getQuestionnairesToShow() {
                 let isFilled = filled.includes(questionnaireType.id)
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const { firstLoginTime } = getters['user/getLogin']
+                const { firstAnnotationTime } = getters['user/getAnnotation']
                 const firstLoginTimeAtZero = moment(firstLoginTime, DATE_FORMAT).format("DD-MM-YYYY")+" 00:00:00"
                 const { hasAnnotatedToday, textCountToday } = getters['user/getAnnotation']
                 const monthDiff = Math.abs(moment(todayTime).diff(
@@ -345,8 +346,9 @@ export function getQuestionnairesToShow() {
                 } else if(questionnaireType.id === "2.2") {
                     isShowing = !isFilled && hasPassedResearchTime
                 } else if(questionnaireType.id === "3.1") {
+                    const time = firstAnnotationTime ?? firstLoginTimeAtZero
                     const weekDiff = Math.abs(moment(todayTime)
-                                    .diff(moment(firstLoginTimeAtZero, DATE_FORMAT), 'weeks'))
+                                    .diff(moment(time, DATE_FORMAT), 'weeks'))
                     const hasPassedOneWeek = weekDiff >= 1
                     isShowing = !isFilled && hasPassedOneWeek
                 } else if(questionnaireType.id === "3.2") {
@@ -366,8 +368,9 @@ export function getQuestionnairesToShow() {
                 } else if(questionnaireType.id === "5.1") {
                     isShowing = !isFilled && hasPassedResearchTime
                 } else if(questionnaireType.id === "6.1") {
+                    const time = firstAnnotationTime ?? firstLoginTimeAtZero
                     const weekDiff = Math.abs(moment(todayTime)
-                                    .diff(moment(firstLoginTimeAtZero, DATE_FORMAT), 'weeks'))
+                                    .diff(moment(time, DATE_FORMAT), 'weeks'))
                     const hasPassedTwoWeeks = weekDiff >= 2
                     isShowing = !isFilled && hasPassedTwoWeeks
                 }

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -318,7 +318,6 @@ export function hasValidLoginTime(givenTime) {
 }
 
 export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
-    console.log(firstQuestionnaireEverStr)
     const qTypes = getQuestionnaireTypes()
     const todayTime = new Date()
     let getters = null
@@ -360,9 +359,6 @@ export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
                     isShowing = !isFilled
                 } else if(questionnaireType.id === "2.2") {
                     isShowing = !isFilled && hasPassedResearchTime
-                    console.log("todayTime", todayTime)
-                    console.log("hasPassedResearchTime", hasPassedResearchTime)
-                    console.log("2.2 isShowing: ", isShowing)
                 } else if(questionnaireType.id === "3.1") {
                     const weekDiff = Math.abs(moment(todayTime)
                                     .diff(moment(defaultTime, DATE_FORMAT), 'weeks'))
@@ -370,9 +366,6 @@ export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
                     isShowing = !isFilled && hasPassedOneWeek
                 } else if(questionnaireType.id === "3.2") {
                     isShowing = !isFilled && hasPassedResearchTime
-                    console.log("todayTime", todayTime)
-                    console.log("hasPassedResearchTime", hasPassedResearchTime)
-                    console.log("3.2 isShowing: ", isShowing)
                 } else if(questionnaireType.id === "4.1") {
                     isShowing = !isFilled && !hasAnnotatedToday
                 }  else if(questionnaireType.id === "4.2") {
@@ -387,9 +380,6 @@ export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
                     isShowing = !isFilled && hasAnnotatedBatch
                 } else if(questionnaireType.id === "5.1") {
                     isShowing = !isFilled && hasPassedResearchTime
-                    console.log("todayTime", todayTime)
-                    console.log("hasPassedResearchTime", hasPassedResearchTime)
-                    console.log("5.1 isShowing: ", isShowing)
                 } else if(questionnaireType.id === "6.1") {
                     const weekDiff = Math.abs(moment(todayTime)
                                     .diff(moment(defaultTime, DATE_FORMAT), 'weeks'))


### PR DESCRIPTION
Issues solved with this PR:
 1. Ability to use slider in radio input (for Demografia questionnaire, economic view and political view)
 2. Sticky text together with toolbar on the top of annotation page
 3. Solve bug with "enter" button on TextInput where it was disabled incorrectly
 4. Add textfield input in "inne" radio option of OffensiveInput
 5. Saving questionnaires states to db to allow resuming from last submitted questionnaire and to allow user using multiple different devices/browsers when working

What's Changed:
 - frontend/components/auth/FormLogin.vue : Add mechanisms to check questionnaire states from db and put them into store
 - frontend/components/questionnaires/QuestionnaireForm.vue : Create questionnaire finished state, set activequestionnaire based on last finished questionnaire + 1, check finished datetime of first questionnaire if available, adjust scale legend placement
 - frontend/components/questionnaires/form/DynamicSelectInput.vue : Minor refactor
 - frontend/components/questionnaires/form/RadioInput.vue : Add ability to show slider input when selected
 - frontend/components/questionnaires/form/ScaleInput.vue : Minor refactor
 - frontend/components/questionnaires/form/SelectInput.vue : Minor refactor
 - frontend/components/questionnaires/form/SliderInput.vue : Refactor to allow usage in radio input, allow string value
 - frontend/components/questionnaires/form/TextInput.vue : Fix "enter" button
 - frontend/components/tasks/affectiveAnnotation/inputs/TextfieldModal.vue : Fix "enter" button
 - frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue : Add textfield input under "inne" radio option
 - frontend/domain/models/example/example.ts : Add ts classes for example states
 - frontend/domain/models/example/exampleRepository.ts : Add api endpoint for retrieving example state list
 - frontend/domain/models/questionnaire/questionnaire.ts : Add ts classes for questionnaire states
 - frontend/domain/models/questionnaire/questionnaireRepository.ts : Add api endpoints related with questionnaire states
 - frontend/i18n/* : Add translations for "inne" subquestion in OffensiveInput
 - frontend/layouts/projects.vue : Add layout name
 - frontend/layouts/questionnaires.vue : Add layout name
 - frontend/middleware/check-questionnaire.js : Add `/` prefix in router push
 - frontend/pages/projects/_id/affective-annotation/index.vue : Make text and toolbar sticky on the top, add initQuestionnaire mechanism
 - frontend/pages/projects/_id/dataset/index.vue : Add setAnnotation mechanism
 - frontend/pages/projects/create.vue : Minor code style adjustment
 - frontend/pages/projects/index.vue : Add checkQuestionnaire mechanism
 - frontend/pages/questionnaires/codziennie_w_trakcie/js/questionnaires.js : Add `typeId` field, adjust questionnaire name
 - frontend/pages/questionnaires/na_koniec/js/questionnaires.js : Add `typeId` field
 - frontend/pages/questionnaires/po_1_tygodniu_i_na_koncu/js/questionnaires.js : Add `typeId` field
 - frontend/pages/questionnaires/po_2_tygodniach/js/questionnaires.js : Add `typeId` field
 - frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js : Add `typeId` field, add slider component in economic view and political view
 - frontend/pages/questionnaires/przed_i_po_badaniu/js/questionnaires.js : Add `typeId` field
 - frontend/repositories/example/apiDocumentRepository.ts : Add api endpoint for retrieving example state list
 - frontend/repositories/questionnaire/apiQuestionnaireRepository.ts : Add api endpoints related with questionnaire states
 - frontend/services/application/example/exampleApplicationService.ts : Add ts classes for example states
 - frontend/services/application/example/exampleData.ts : Add ts classes for example states
 - frontend/services/application/questionnaire/questionnaireApplicationService.ts : Add ts classes for questionnaire states
 - frontend/services/application/questionnaire/questionnaireData.ts : Add ts classes for questionnaire states
 - frontend/store/user.js : Add `firstQuestionnaireEverDate` param to `initQuestionnaire()` in order to allow calculation when user logs in from different devices
 - frontend/utils/questionnaires.js : Adjust `setQuestionnaireIds()` calculation, add first questionnaire date string as parameter to `getQuestionnairesToShow()`


Screenshots: 
![image](https://user-images.githubusercontent.com/12537724/205733020-35769e31-55d0-4827-88fa-4b040d204bb2.png)
![image](https://user-images.githubusercontent.com/12537724/205735228-3dc18ab9-e7c1-41c3-af7e-564d0c023978.png)
