### PR TITLE
Feat: Display total number of annotated texts, adjust final questionnaires timing

### DIFF
--- a/frontend/components/utils/BigNumberCard.vue
+++ b/frontend/components/utils/BigNumberCard.vue
@@ -1,0 +1,47 @@
+<template>
+  <v-card flat class="mb-2">
+    <v-card-text class="d-flex justify-start align-end">
+      <span class="card-label mr-3">
+        {{ label }}
+      </span>
+      <span class="card-value">
+        {{ valueString }}
+      </span>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+import Vue from 'vue'
+
+export default Vue.extend({
+  props: {
+    label: {
+      type: String,
+      default: ""
+    },
+    value: {
+      type: Number,
+      required: true
+    }
+  },
+
+  computed: {
+    valueString() {
+      const currentLocale = this.$i18n.locale
+      return this.value.toLocaleString(currentLocale)
+    }
+  }
+})
+</script>
+
+<style>
+.card-label {
+  font-size: 0.8rem;
+}
+
+.card-value {
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+</style>

--- a/frontend/i18n/de/projects/statistics.js
+++ b/frontend/i18n/de/projects/statistics.js
@@ -2,5 +2,6 @@ export default {
   statistics: 'Statistiken',
   progress: ['Abgeschlossen', 'Unvollständig'],
   labelStats: 'Labelstatistiken',
-  userStats: 'Nutzerstatistiken'
+  userStats: 'Nutzerstatistiken',
+  totalTextsAnnotated : "Gesamtzahl der Texte, die Sie kommentiert haben:"
 }

--- a/frontend/i18n/en/projects/statistics.js
+++ b/frontend/i18n/en/projects/statistics.js
@@ -2,5 +2,6 @@ export default {
   statistics: 'Metrics',
   progress: ['Completed', 'Incomplete'],
   labelStats: 'Label stats',
-  userStats: 'User stats'
+  userStats: 'User stats',
+  totalTextsAnnotated : "Total number of texts that you have annotated:"
 }

--- a/frontend/i18n/fr/projects/statistics.js
+++ b/frontend/i18n/fr/projects/statistics.js
@@ -2,5 +2,6 @@ export default {
   statistics: 'Statistiques',
   progress: ['Complété', 'Incomplet'],
   labelStats: 'Étiqueter les stats',
-  userStats: 'Stats des utilisateurs'
+  userStats: 'Stats des utilisateurs',
+  totalTextsAnnotated : "Nombre total de textes que vous avez annotés:"
 }

--- a/frontend/i18n/pl/projects/statistics.js
+++ b/frontend/i18n/pl/projects/statistics.js
@@ -2,5 +2,6 @@ export default {
   statistics: 'Metryki',
   progress: ['Ukończone', 'Niekompletne'],
   labelStats: 'Statystyki etykiet',
-  userStats: 'Statystyki użytkownika'
+  userStats: 'Statystyki użytkownika',
+  totalTextsAnnotated : "Łączna liczba tekstów, które zaanotowałeś/-aś:"
 }

--- a/frontend/i18n/zh/projects/statistics.js
+++ b/frontend/i18n/zh/projects/statistics.js
@@ -2,5 +2,6 @@ export default {
   statistics: '统计',
   progress: ['已完成', '未完成'],
   labelStats: '标签统计',
-  userStats: '用户统计'
+  userStats: '用户统计',
+  totalTextsAnnotated : "您已注释的文本总数:"
 }

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -24,7 +24,7 @@ import _ from 'lodash'
     6. Ankieta po 2 tygodniach badania
 */ 
 
-const RESEARCH_TIME_IN_MONTHS = 3
+const RESEARCH_TIME_IN_MONTHS = 2.5
 const TEXT_BATCH_COUNT = 20
 const DATE_FORMAT = "DD-MM-YYYY HH:mm:ss"
 const DATE_ONLY_FORMAT = "DD-MM-YYYY"
@@ -343,10 +343,10 @@ export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
                 const { hasAnnotatedToday, textCountToday } = getters['user/getAnnotation']
                 const defaultTime = firstAnnotationTime || firstLoginTimeAtZero
                 const monthDiff1 = Math.abs(moment(todayTime).diff(
-                    moment(firstLoginTimeAtZero, DATE_FORMAT), 'months'
+                    moment(firstLoginTimeAtZero, DATE_FORMAT), 'months', true
                 ))
                 const monthDiff2 = Math.abs(moment(todayTime).diff(
-                    moment(firstQuestionnaireEverDate), 'months'
+                    moment(firstQuestionnaireEverDate), 'months', true
                 ))
                 const hasPassedResearchTime = monthDiff2 >= RESEARCH_TIME_IN_MONTHS || monthDiff1 >= RESEARCH_TIME_IN_MONTHS
                 let isShowing = false


### PR DESCRIPTION
This PR aims to solve 2 things: (1) Displaying the total number of annotated texts on the project list page of a user, (2) Adjusting the final questionnaires timing to appear after 2.5 months.

What's new:
 - frontend/components/utils/BigNumberCard.vue : New util card for showing a number with a label string, where the number is formatted into string following the current locale.

What's changed:
 - frontend/pages/projects/index.vue : Display the total annotated texts of the user using the new component.
 - frontend/i18n/* : Add translations for the annotated texts count label.
 - frontend/utils/questionnaires.js : Change research time to 2.5 months, add `true` argument to moment diff() to make returned value in float.

Screenshots:
<img width="960" alt="ss-1" src="https://user-images.githubusercontent.com/64476430/208158811-60b61205-e06f-4886-b8cf-93681cf5d588.PNG">
<img width="960" alt="ss-2" src="https://user-images.githubusercontent.com/64476430/208158815-35531813-db1c-44a9-8881-3d59eaa19163.PNG">
