### PR TITLE
fix: Adjust slider thumb & bottom margin, kw input dialog height

### DIFF
--- a/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="widget">
-    <v-row class="widget-row" justify="center" align="center">
+    <v-row class="widget-row" justify="center" align="top">
       <v-col :cols="(withCheckbox) ? 3 : 4" class="widget-row__category">
         {{ categoryLabel }}
       </v-col>
@@ -19,7 +19,8 @@
           track-color='grey'
           :hint="hint"
           persistent-hint
-          :thumb-size="sliderThumbSize"
+          thumb-label="always"
+          thumb-size="18"
           :thumb-color="sliderThumbColor"
           @click="markClicked"
           @change="valueChangeHandler"
@@ -144,6 +145,7 @@ export default {
 .widget-row {
   word-wrap: normal;
   word-break: normal;
+  padding-bottom: 30px;
 
   &__category {
     font-size: 0.8rem;
@@ -158,6 +160,10 @@ export default {
     padding: 0 !important;
 
     .v-input {
+      &__slot {
+        margin-bottom: 0 !important;
+      }
+
       &__prepend-outer, &__append-outer {
         font-size: 0.65rem;
         line-height: 0.8;

--- a/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
+++ b/frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue
@@ -37,13 +37,14 @@
       width="600"
       class="widget-dialog"
     >
-      <v-card>
+      <v-card height="250">
         <v-card-title class="widget-dialog__title">
           {{ question }}
         </v-card-title>
-        <v-card-text  class="widget-dialog__text">
+        <v-card-text class="widget-dialog__text">
           <p class="widget-dialog__hint">{{ $t('annotation.affectiveTextlabelHint') }}</p>
           <p class="widget-dialog__warning">{{ dialogErrorMessage }}</p>
+          <v-spacer/>
           <seq2seq-box
             :text="text"
             :annotations="answers"


### PR DESCRIPTION
This PR solves minor issues related to annotation page appearance:
 - Adding a thumb label to each slider
 - Making the hint under each slider a little bit closer to the slider itself while increasing the bottom padding
 - Making tags/impressions input dialog's height fixed

What's Changed:
 - frontend/components/tasks/affectiveAnnotation/inputs/Slider.vue: Add thumb label, adjust hint placement and bottom padding
 - frontend/components/tasks/affectiveAnnotation/inputs/TextfieldWithSeq2Seq.vue: Make input dialog's height fixed

Screenshots:
<img width="532" alt="fixSliderMarginThumb" src="https://user-images.githubusercontent.com/64476430/212145274-727fd114-e48b-4fc0-865d-5f029eeebe3c.PNG">
<img width="960" alt="fixHeightDialog" src="https://user-images.githubusercontent.com/64476430/212145280-2cb016d6-7b72-4f4f-9267-cf846e600e55.PNG">
