### PR TITLE
Maintain backward compatibility with poetry

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -7,6 +7,7 @@ WORKDIR /backend
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
+ENV GET_POETRY_IGNORE_DEPRECATION 1
 
 RUN groupadd -g 61000 doccano \
   && useradd -g 61000 -l -M -s /bin/false -u 61000 doccano
@@ -23,7 +24,7 @@ RUN apt-get update \
     g++=4:* \
     curl \
  && pip install --upgrade --no-cache-dir pip \
- && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python - \
+ && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/1.3/get-poetry.py | python - \
  && PATH="${PATH}:$HOME/.poetry/bin" \
  && poetry config virtualenvs.create false \
  && poetry install --no-dev --no-root \


### PR DESCRIPTION
While working on additional annotation modes, Poetry changed the installation method and removed the installer from the main repository, from where it was previously downloaded.

The suggested link points to the latest available version of the installer, which is additionally aware of the upcoming installation mode change. The introduced environment variable allows you to use the old installer mode. The new one requires additional testing and will be tested when our version is updated with changes from the base doccano repository.

The best way to test the change is to build the images from scratch.