### PR TITLE
Fix: questionnaires average time APIs 

### DIFF
--- a/backend/questionnaires/managers.py
+++ b/backend/questionnaires/managers.py
@@ -38,7 +38,7 @@ class QuestionnaireStateManager(Manager):
         tz = timezone.get_current_timezone()
         startdate = timezone.make_aware(datetime.datetime.fromordinal(startdate.toordinal()), tz, is_dst=True)
         enddate = timezone.make_aware(datetime.datetime.fromordinal(enddate.toordinal()), tz, is_dst=True)
-        finished_time_questionnaires = self.filter(finished_by__in=users, finished_at__gte=startdate, finished_at__lte=enddate).values()
+        finished_time_questionnaires = self.filter(finished_by__in=users, finished_at__gte=startdate, finished_at__lte=enddate).values().order_by("finished_at")
         return finished_time_questionnaires
 
 
@@ -46,6 +46,6 @@ class AnswerStateManager(Manager):
     def get_answers_time_by_user_in_given_period(self, questionnaire_ids, user, date):
         return (
             self.filter(user_id=user, created_at__date=date, question_id__questionnaire_id__in=questionnaire_ids)
-            .values("created_at", "question_id__questionnaire_id")
+            .values("created_at", "question_id__questionnaire_id").order_by("created_at")
         )
         


### PR DESCRIPTION
Hello, I've just found a bug in the APIs for calculating the daily average time user spend on questionnaire. For some users the time is too big (>24h) that's why I wondered how it's possible :sweat_smile: The reason is because previously I assumed that the user will do the questionnaires in order then the started time will be in order but somehow they're not in order :sweat_smile: So to handle it I sort the request data by time before use them for calculation. I'm so sorry for the bug :sweat_smile:

Previously:
![image](https://user-images.githubusercontent.com/17596118/212896932-4a5aec8b-a071-48cd-a7ac-5f8a9428411e.png)
![image](https://user-images.githubusercontent.com/17596118/212896949-1ddf4237-c7d6-4430-ad32-23eeba18356a.png)

Now (it's correct now :sweat_smile: ):
![image](https://user-images.githubusercontent.com/17596118/212897045-b8912180-e5d6-4e29-a936-a4aeea647a5c.png)
![image](https://user-images.githubusercontent.com/17596118/212897065-8a938f51-44a1-4fbe-988e-76b53dc2c84d.png)

 What's changed:
- `backend/questionnaires/managers.py`: added sort to sort data by time