### PR TITLE
feat: Add API endpoints for report using Active Minutes to FE

### DIFF
--- a/frontend/domain/models/statistics/statistics.ts
+++ b/frontend/domain/models/statistics/statistics.ts
@@ -27,13 +27,13 @@ export class AllUsersItemDoneCount {
 export class DailyAverageTime {
   constructor(
     public date: string,
-    public averageTimeInSeconds: number
+    public averageTimeInMinutes: number
   ) {}
 
   toObject(): Object {
     return {
       date: this.date,
-      averageTimeInSeconds: this.averageTimeInSeconds
+      averageTimeInMinutes: this.averageTimeInMinutes
     }
   }
 }
@@ -41,14 +41,14 @@ export class DailyAverageTime {
 export class UserAverageTime {
   constructor(
     public userId: number,
-    public meanTimeInSeconds: number,
+    public meanTimeInMinutes: number,
     public dailyAverageTime: DailyAverageTime[]
   ) {}
 
   toObject(): Object {
     return {
       userId: this.userId,
-      meanTimeInSeconds: this.meanTimeInSeconds,
+      meanTimeInMinutes: this.meanTimeInMinutes,
       dailyAverageTime: this.dailyAverageTime
     }
   }
@@ -56,13 +56,13 @@ export class UserAverageTime {
 
 export class AllUsersAverageTime {
   constructor(
-    public meanTimeInSeconds: number,
+    public meanTimeInMinutes: number,
     public dailyAverageTime: DailyAverageTime[]
   ) {}
 
   toObject(): Object {
     return {
-      meanTimeInSeconds: this.meanTimeInSeconds,
+      meanTimeInMinutes: this.meanTimeInMinutes,
       dailyAverageTime: this.dailyAverageTime
     }
   }

--- a/frontend/domain/models/statistics/statisticsRepository.ts
+++ b/frontend/domain/models/statistics/statisticsRepository.ts
@@ -14,4 +14,10 @@ export interface StatisticsRepository {
   fetchAllUsersAverageTimeAnnotation(startDate: string, endDate: string): Promise<AllUsersAverageTime>
   fetchAllUsersAverageTimeQuestionnaire(startDate: string, endDate: string): Promise<AllUsersAverageTime>
   fetchAllUsersAverageTimeText(startDate: string, endDate: string): Promise<AllUsersAverageTime>
+  fetchUsrAvgTimeAnnotationActiveMinutes(userId: string, startDate: string, endDate: string): Promise<UserAverageTime>
+  fetchUsrAvgTimeQuestionnaireActiveMinutes(userId: string, startDate: string, endDate: string): Promise<UserAverageTime>
+  fetchUsrAvgTimeTextActiveMinutes(userId: string, startDate: string, endDate: string): Promise<UserAverageTime>
+  fetchAllUsersAvgTimeAnnotationActiveMinutes(startDate: string, endDate: string): Promise<AllUsersAverageTime>
+  fetchAllUsersAvgTimeQuestionnaireActiveMinutes(startDate: string, endDate: string): Promise<AllUsersAverageTime>
+  fetchAllUsersAvgTimeTextActiveMinutes(startDate: string, endDate: string): Promise<AllUsersAverageTime>
 }

--- a/frontend/i18n/de/projects/statistics.js
+++ b/frontend/i18n/de/projects/statistics.js
@@ -6,6 +6,7 @@ export default {
   totalTextsAnnotated : "Gesamtzahl der Texte, die Sie kommentiert haben:",
   weeklyStats: {
     button: "Wöchentliche Statistiken",
+    toggleActiveMinutes: "Aktiv-Minuten verwenden",
     weekSelectPrompt: '-- Wählen Sie einen Wochenbereich aus --',
     startDate: 'Anfangsdatum: ',
     endDate: 'Enddatum: ',
@@ -14,16 +15,16 @@ export default {
       title: "Wöchentliche Statistiken von allen Benutzern",
       totalAnnotations: "Gesamte Anmerkungen in dieser Woche:",
       totalEveningQuestionnaires: "Gesamtzahl der in dieser Woche erstellten Abendfragebögen:",
-      avgTimeAnnotate: "Durchschnittliche Zeit, die Nutzer täglich mit dem Kommentieren verbringen (Stunde):",
-      avgTimeQuestionnaire: "Durchschnittliche Zeit, die Benutzer täglich mit Fragebögen verbringen (Stunde):",
+      avgTimeAnnotate: "Durchschnittliche Zeit, die Nutzer täglich mit dem Kommentieren verbringen (Minute):",
+      avgTimeQuestionnaire: "Durchschnittliche Zeit, die Benutzer täglich mit Fragebögen verbringen (Minute):",
       avgTimeText: "Durchschnittliche Zeit, die Benutzer mit dem Annotieren eines einzelnen Textes verbringen (Minute):"
     },
     individual: {
       title: "Wöchentliche Statistiken von einzelnen Nutzern",
       totalAnnotations: "Gesamtanzahl der von diesem Benutzer in dieser Woche gemachten Anmerkungen:",
       totalEveningQuestionnaires: "Gesamte Abendfragebögen dieses Benutzers in dieser Woche:",
-      avgTimeAnnotate: "Durchschnittliche Zeit, die der Benutzer täglich mit Annotieren verbringt (Stunde):",
-      avgTimeQuestionnaire: "Durchschnittliche Zeit, die der Benutzer täglich mit Fragebögen verbringt (Stunde):",
+      avgTimeAnnotate: "Durchschnittliche Zeit, die der Benutzer täglich mit Annotieren verbringt (Minute):",
+      avgTimeQuestionnaire: "Durchschnittliche Zeit, die der Benutzer täglich mit Fragebögen verbringt (Minute):",
       avgTimeText: "Durchschnittliche Zeit, die der Benutzer mit dem Annotieren eines einzelnen Textes verbringt (Minute):"
     }
   }

--- a/frontend/i18n/en/projects/statistics.js
+++ b/frontend/i18n/en/projects/statistics.js
@@ -6,6 +6,7 @@ export default {
   totalTextsAnnotated : "Total number of texts that you have annotated:",
   weeklyStats: {
     button: "Weekly Statistics",
+    toggleActiveMinutes: "Use Active Minutes",
     weekSelectPrompt: '-- Select a week range --',
     startDate: 'Start Date: ',
     endDate: 'End Date: ',
@@ -14,16 +15,16 @@ export default {
       title: "Weekly Statistics from All Users",
       totalAnnotations: "Total annotations made this week:",
       totalEveningQuestionnaires: "Total evening questionnaires made this week:",
-      avgTimeAnnotate: "Average time users spend daily with annotating (hour):",
-      avgTimeQuestionnaire: "Average time users spend daily with questionnaires (hour):",
+      avgTimeAnnotate: "Average time users spend daily with annotating (minute):",
+      avgTimeQuestionnaire: "Average time users spend daily with questionnaires (minute):",
       avgTimeText: "Average time users spend to annotate a single text (minute):"
     },
     individual: {
       title: "Weekly Statistics from Individual User",
       totalAnnotations: "Total annotations made by this user this week:",
       totalEveningQuestionnaires: "Total evening questionnaires made by this user this week:",
-      avgTimeAnnotate: "Average time the user spends daily with annotating (hour):",
-      avgTimeQuestionnaire: "Average time the user spends daily with questionnaires (hour):",
+      avgTimeAnnotate: "Average time the user spends daily with annotating (minute):",
+      avgTimeQuestionnaire: "Average time the user spends daily with questionnaires (minute):",
       avgTimeText: "Average time the user spends to annotate a single text (minute):"
     }
   }

--- a/frontend/i18n/fr/projects/statistics.js
+++ b/frontend/i18n/fr/projects/statistics.js
@@ -6,6 +6,7 @@ export default {
   totalTextsAnnotated : "Nombre total de textes que vous avez annotés:",
   weeklyStats: {
     button: "Statistiques Hebdomadaires",
+    toggleActiveMinutes: "Utiliser les minutes actives",
     weekSelectPrompt: '-- Sélectionnez une plage de semaines --',
     startDate: "Date de début : ",
     endDate: "Date de fin : ",
@@ -14,16 +15,16 @@ export default {
       title: "Statistiques hebdomadaires de tous les utilisateurs",
       totalAnnotations: "Total des annotations effectuées cette semaine :",
       totalEveningQuestionnaires: "Total des questionnaires du soir réalisés cette semaine :",
-      avgTimeAnnotate: "Temps moyen que les utilisateurs consacrent quotidiennement à l'annotation (heure) :",
-      avgTimeQuestionnaire: "Temps moyen que les utilisateurs consacrent quotidiennement aux questionnaires (heure) :",
+      avgTimeAnnotate: "Temps moyen que les utilisateurs consacrent quotidiennement à l'annotation (minute) :",
+      avgTimeQuestionnaire: "Temps moyen que les utilisateurs consacrent quotidiennement aux questionnaires (minute) :",
       avgTimeText: "Temps moyen que les utilisateurs passent à annoter un seul texte (minute) :"
     },
     individual: {
       title: "Statistiques hebdomadaires d'un utilisateur individuel",
       totalAnnotations: "Total des annotations faites par cet utilisateur cette semaine :",
       totalEveningQuestionnaires: "Total des questionnaires du soir réalisés par cet utilisateur cette semaine :",
-      avgTimeAnnotate: "Temps moyen que l'utilisateur consacre quotidiennement à l'annotation (heure) :",
-      avgTimeQuestionnaire: "Temps moyen que l'utilisateur consacre quotidiennement aux questionnaires (heure) :",
+      avgTimeAnnotate: "Temps moyen que l'utilisateur consacre quotidiennement à l'annotation (minute) :",
+      avgTimeQuestionnaire: "Temps moyen que l'utilisateur consacre quotidiennement aux questionnaires (minute) :",
       avgTimeText: "Temps moyen que l'utilisateur passe à annoter un seul texte (minute) :"
     }
   }

--- a/frontend/i18n/pl/projects/statistics.js
+++ b/frontend/i18n/pl/projects/statistics.js
@@ -6,6 +6,7 @@ export default {
   totalTextsAnnotated : "Łączna liczba tekstów, które zaanotowałeś/-aś:",
   weeklyStats: {
     button: "Statystyki Tygodniowe",
+    toggleActiveMinutes: "Wykorzystaj Aktywne Minuty",
     weekSelectPrompt: '-- Wybierz zakres tygodniowy --',
     startDate: 'Data rozpoczęcia: ',
     endDate: 'Data zakończenia: ',
@@ -14,16 +15,16 @@ export default {
       title: "Statystyki tygodniowe od wszystkich użytkowników",
       totalAnnotations: "Łącznie anotacje wykonane w tym tygodniu:",
       totalEveningQuestionnaires: "Łącznie ankiety wieczorne wykonane w tym tygodniu:",
-      avgTimeAnnotate: "Średni czas, jaki użytkownicy spędzają dziennie z anotacjami (godzina):",
-      avgTimeQuestionnaire: "Średni czas, jaki użytkownicy spędzają dziennie z kwestionariuszami (godzina):",
+      avgTimeAnnotate: "Średni czas, jaki użytkownicy spędzają dziennie z anotacjami (minuta):",
+      avgTimeQuestionnaire: "Średni czas, jaki użytkownicy spędzają dziennie z kwestionariuszami (minuta):",
       avgTimeText: "Średni czas, jaki użytkownicy spędzają na pojedynczym tekście (minuta):"
     },
     individual: {
       title: "Statystyki tygodniowe od pojedynczego użytkownika",
       totalAnnotations: "Łącznie anotacje wykonane przez tego użytkownika w tym tygodniu:",
       totalEveningQuestionnaires: "Łącznie ankiety wieczorne wykonane przez tego użytkownika w tym tygodniu:",
-      avgTimeAnnotate: "Średni czas, jaki ten użytkownik spędza dziennie z anotacjami (godzina):",
-      avgTimeQuestionnaire: "Średni czas, jaki ten użytkownik spędza dziennie z kwestionariuszami (godzina):",
+      avgTimeAnnotate: "Średni czas, jaki ten użytkownik spędza dziennie z anotacjami (minuta):",
+      avgTimeQuestionnaire: "Średni czas, jaki ten użytkownik spędza dziennie z kwestionariuszami (minuta):",
       avgTimeText: "Średni czas, jaki ten użytkownik spędza na pojedynczym tekście (minuta):"
     }
   }

--- a/frontend/i18n/zh/projects/statistics.js
+++ b/frontend/i18n/zh/projects/statistics.js
@@ -6,6 +6,7 @@ export default {
   totalTextsAnnotated : "您已注释的文本总数:",
   weeklyStats: {
     button: "每周统计",
+    toggleActiveMinutes: "使用有效会议记录",
     weekSelectPrompt: "--选择一个星期的范围--",
     startDate: "开始日期: ",
     endDate: "结束日期: ",
@@ -14,16 +15,16 @@ export default {
       title: "来自所有用户的每周统计",
       totalAnnotations: "本周所做的总注解:",
       totalEveningQuestionnaires: "本周所做的晚间调查问卷总数:",
-      avgTimeAnnotate: "用户每天花在注释上的平均时间 (小时):",
-      avgTimeQuestionnaire: "用户每天花在调查问卷上的平均时间 (小时):",
+      avgTimeAnnotate: "用户每天花在注释上的平均时间 (分钟):",
+      avgTimeQuestionnaire: "用户每天花在调查问卷上的平均时间 (分钟):",
       avgTimeText: "用户花在注释一个文本上的平均时间 (分钟):",
     },
     individual: {
       title: "来自个人用户的每周统计",
       totalAnnotations: "本周该用户的总注解数:",
       totalEveningQuestionnaires: "本周该用户所做的晚间调查问卷总数:",
-      avgTimeAnnotate: "用户每天花在注释上的平均时间 (小时):",
-      avgTimeQuestionnaire: "该用户每天花在调查问卷上的平均时间 (小时):",
+      avgTimeAnnotate: "用户每天花在注释上的平均时间 (分钟):",
+      avgTimeQuestionnaire: "该用户每天花在调查问卷上的平均时间 (分钟):",
       avgTimeText: "用户注释一个文本所花的平均时间 (分钟):"
     }
   }

--- a/frontend/repositories/statistics/apiStatistics.ts
+++ b/frontend/repositories/statistics/apiStatistics.ts
@@ -32,12 +32,12 @@ export class APIStatisticsRepository implements StatisticsRepository {
     let dailyAverageTime = []
     if ("daily_average_annotation_time" in response.data) {
       dailyAverageTime = response.data.daily_average_annotation_time.map((item: any) => 
-        new DailyAverageTime(item.date, item['average_annotation_time (seconds)'])
+        new DailyAverageTime(item.date, (item['average_annotation_time (seconds)'] / 60))
       )
     }
     return new UserAverageTime(
       parseInt(userId),
-      response.data['average_annotation_time (seconds)'],
+      (response.data['average_annotation_time (seconds)'] / 60),
       dailyAverageTime
     )
   }
@@ -48,12 +48,12 @@ export class APIStatisticsRepository implements StatisticsRepository {
     let dailyAverageTime = []
     if ("daily_questionnaire_time" in response.data) {
       dailyAverageTime = response.data.daily_questionnaire_time.map((item: any) => 
-        new DailyAverageTime(item.date, item['total_time (seconds)'])
+        new DailyAverageTime(item.date, (item['total_time (seconds)'] / 60))
       )
     }
     return new UserAverageTime(
       parseInt(userId),
-      response.data['average_daily_questionnaire_time (seconds)'],
+      (response.data['average_daily_questionnaire_time (seconds)'] / 60),
       dailyAverageTime
     )
   }
@@ -64,12 +64,12 @@ export class APIStatisticsRepository implements StatisticsRepository {
     let dailyAverageTime = []
     if ("daily_average_annotation_time" in response.data) {
       dailyAverageTime = response.data.daily_average_annotation_time.map((item: any) => 
-        new DailyAverageTime(item.date, item['average_annotation_time (seconds)'])
+        new DailyAverageTime(item.date, (item['average_annotation_time (seconds)'] / 60))
       )
     }
     return new UserAverageTime(
       parseInt(userId),
-      response.data['average_annotation_time (seconds)'],
+      (response.data['average_annotation_time (seconds)'] / 60),
       dailyAverageTime
     )
   }
@@ -90,9 +90,9 @@ export class APIStatisticsRepository implements StatisticsRepository {
     const url = `/report/all-users-avg-daily-annotation-time/${startDate}/${endDate}/`
     const response = await this.request.get(url)
     return new AllUsersAverageTime(
-      response.data['average_annotation_time (seconds)'],
+      (response.data['average_annotation_time (seconds)'] / 60),
       response.data.daily_average_annotation_time.map((item: any) => 
-        new DailyAverageTime(item.date, item['avg_annotation_time_daily (seconds)'])
+        new DailyAverageTime(item.date, (item['avg_annotation_time_daily (seconds)'] / 60))
       )
     )
   }
@@ -101,9 +101,9 @@ export class APIStatisticsRepository implements StatisticsRepository {
     const url = `/report/all-users-avg-daily-questionnaire-time/${startDate}/${endDate}/`
     const response = await this.request.get(url)
     return new AllUsersAverageTime(
-      response.data['average_daily_questionnaire_time (seconds)'],
+      (response.data['average_daily_questionnaire_time (seconds)'] / 60),
       response.data.daily_questionnaire_time.map((item: any) => 
-        new DailyAverageTime(item.date, item['avg_questionnaire_time_daily (seconds)'])
+        new DailyAverageTime(item.date, (item['avg_questionnaire_time_daily (seconds)'] / 60))
       )
     )
   }
@@ -112,9 +112,90 @@ export class APIStatisticsRepository implements StatisticsRepository {
     const url = `/report/all-users-average-annotation-time/${startDate}/${endDate}/`
     const response = await this.request.get(url)
     return new AllUsersAverageTime(
-      response.data['average_annotation_time (seconds)'],
+      (response.data['average_annotation_time (seconds)'] / 60),
       response.data.daily_average_annotation_time.map((item: any) => 
-        new DailyAverageTime(item.date, item['avg_annotation_time_single_text (seconds)'])
+        new DailyAverageTime(item.date, (item['avg_annotation_time_single_text (seconds)'] / 60))
+      )
+    )
+  }
+
+  async fetchUsrAvgTimeAnnotationActiveMinutes(userId: string, startDate: string, endDate: string): Promise<UserAverageTime> {
+    const url = `/report/user-daily-avg-active-minutes/${userId}/${startDate}/${endDate}/`
+    const response = await this.request.get(url)
+    let dailyAverageTime = []
+    if ("daily_active_annotation_time" in response.data) {
+      dailyAverageTime = response.data.daily_active_annotation_time.map((item: any) => 
+        new DailyAverageTime(item.date, item.total_active_minutes)
+      )
+    }
+    return new UserAverageTime(
+      parseInt(userId),
+      response.data['average_daily_active_annotation_time (minutes)'],
+      dailyAverageTime
+    )
+  }
+
+  async fetchUsrAvgTimeQuestionnaireActiveMinutes(userId: string, startDate: string, endDate: string): Promise<UserAverageTime> {
+    const url = `/report/user-questionnaire-active-minutes/${userId}/${startDate}/${endDate}/`
+    const response = await this.request.get(url)
+    let dailyAverageTime = []
+    if ("daily_questionnaire_mins" in response.data) {
+      dailyAverageTime = response.data.daily_questionnaire_mins.map((item: any) => 
+        new DailyAverageTime(item.date, item.total_active_mins)
+      )
+    }
+    return new UserAverageTime(
+      parseInt(userId),
+      response.data.avg_questionnaire_active_mins,
+      dailyAverageTime
+    )
+  }
+
+  async fetchUsrAvgTimeTextActiveMinutes(userId: string, startDate: string, endDate: string): Promise<UserAverageTime> {
+    const url = `/report/user-avg-single-text-active-minutes/${userId}/${startDate}/${endDate}/`
+    const response = await this.request.get(url)
+    let dailyAverageTime = []
+    if ("daily_avg_sinlge_text_annotation_time (active minutes)" in response.data) {
+      dailyAverageTime = response.data['daily_avg_sinlge_text_annotation_time (active minutes)'].map((item: any) => 
+        new DailyAverageTime(item.date, item['avg_active_annotation_time_daily (minutes)'])
+      )
+    }
+    return new UserAverageTime(
+      parseInt(userId),
+      (typeof response.data['average_single_text_annotation_time (active minutes)'] === 'number') ? response.data['average_single_text_annotation_time (active minutes)'] : 0,
+      dailyAverageTime
+    )
+  }
+
+  async fetchAllUsersAvgTimeAnnotationActiveMinutes(startDate: string, endDate: string): Promise<AllUsersAverageTime> {
+    const url = `/report/all-users-avg-active-minutes/${startDate}/${endDate}/`
+    const response = await this.request.get(url)
+    return new AllUsersAverageTime(
+      response.data['average_daily_active_annotation_time (minutes)'],
+      response.data.daily_active_annotation_time.map((item: any) => 
+        new DailyAverageTime(item.date, item['avg_active_annotation_time_daily (minutes)'])
+      )
+    )
+  }
+
+  async fetchAllUsersAvgTimeQuestionnaireActiveMinutes(startDate: string, endDate: string): Promise<AllUsersAverageTime> {
+    const url = `/report/all-users-questionnaire-active-minutes/${startDate}/${endDate}/`
+    const response = await this.request.get(url)
+    return new AllUsersAverageTime(
+      response.data.all_user_avg_questionnaire_active_mins,
+      response.data.daily_avg_questionnaire_active_mins.map((item: any) => 
+        new DailyAverageTime(item.date, item.avg_daily_questionnaire_active_mins)
+      )
+    )
+  }
+
+  async fetchAllUsersAvgTimeTextActiveMinutes(startDate: string, endDate: string): Promise<AllUsersAverageTime> {
+    const url = `/report/all-users-avg-single-text-active-minutes/${startDate}/${endDate}/`
+    const response = await this.request.get(url)
+    return new AllUsersAverageTime(
+      (typeof response.data['all_user_avg_single_text_ann_time (active minutes)'] === 'number') ? response.data['all_user_avg_single_text_ann_time (active minutes)'] : 0,
+      response.data['daily_avg_single_text_ann_time (active minutes)'].map((item: any) => 
+        new DailyAverageTime(item.date, item['avg_single_text_ann_time_per_day (active minutes)'])
       )
     )
   }

--- a/frontend/services/application/statistics/statisticsApplicationService.ts
+++ b/frontend/services/application/statistics/statisticsApplicationService.ts
@@ -46,4 +46,28 @@ export class StatisticsApplicationService {
   public async fetchAllUsersAverageTimeText(startDate: string, endDate: string): Promise<AllUsersAverageTime> {
     return await this.repository.fetchAllUsersAverageTimeText(startDate, endDate)
   }
+
+  public async fetchUsrAvgTimeAnnotationActiveMinutes(userId: string, startDate: string, endDate: string): Promise<UserAverageTime> {
+    return await this.repository.fetchUsrAvgTimeAnnotationActiveMinutes(userId, startDate, endDate)
+  }
+
+  public async fetchUsrAvgTimeQuestionnaireActiveMinutes(userId: string, startDate: string, endDate: string): Promise<UserAverageTime> {
+    return await this.repository.fetchUsrAvgTimeQuestionnaireActiveMinutes(userId, startDate, endDate)
+  }
+
+  public async fetchUsrAvgTimeTextActiveMinutes(userId: string, startDate: string, endDate: string): Promise<UserAverageTime> {
+    return await this.repository.fetchUsrAvgTimeTextActiveMinutes(userId, startDate, endDate)
+  }
+  
+  public async fetchAllUsersAvgTimeAnnotationActiveMinutes(startDate: string, endDate: string): Promise<AllUsersAverageTime> {
+    return await this.repository.fetchAllUsersAvgTimeAnnotationActiveMinutes(startDate, endDate)
+  }
+
+  public async fetchAllUsersAvgTimeQuestionnaireActiveMinutes(startDate: string, endDate: string): Promise<AllUsersAverageTime> {
+    return await this.repository.fetchAllUsersAvgTimeQuestionnaireActiveMinutes(startDate, endDate)
+  }
+
+  public async fetchAllUsersAvgTimeTextActiveMinutes(startDate: string, endDate: string): Promise<AllUsersAverageTime> {
+    return await this.repository.fetchAllUsersAvgTimeTextActiveMinutes(startDate, endDate)
+  }
 }


### PR DESCRIPTION
This PR mainly aims to add the new API endpoints created in PR #84 to the report page. In addition:
 1. A toggle is added to the top of the report page to disable calculation based on active minutes. This way, we can switch easily between the old APIs (which are based on time ranges between start timestamps and end timestamps) and the new APIs (which are based on active minutes). By default, this toggle is set to `true`, meaning that we use the Active Minutes APIs by default.
 2. All time units have been changed to `minute`. Previously, some charts have `hour` unit while some others have `minute` unit. Now, all charts use the `minute` unit, which hopefully can help make them easier to understand quickly.

Screenshots:
<img width="960" alt="pr1" src="https://user-images.githubusercontent.com/64476430/217008861-2203dc0a-ece6-427c-972f-c4791b3aa742.PNG">
<img width="960" alt="pr2" src="https://user-images.githubusercontent.com/64476430/217008864-c758b77e-c4cb-4464-be91-ba73db0d2ef7.PNG">

What's changed:
 - frontend/domain/models/statistics/statistics.ts : Rename attributes names from `xxInSeconds` to `xxInMinutes`
 - frontend/domain/models/statistics/statisticsRepository.ts : Add new methods to interface StatisticsRepository for report based on active minutes
 - frontend/repositories/statistics/apiStatistics.ts : (1) Add new API endpoints for report based on active minutes, (2) Convert data from old APIs from seconds to minutes
 - frontend/services/application/statistics/statisticsApplicationService.ts : Register the new services for report based on active minutes
 - frontend/pages/statistics/index.vue : (1) Add toggle for using or not using active minutes APIs, (2) Use the new services for report data based on active minutes, (3) Adjust all charts to use `minute` time unit
 - frontend/i18n/* : Add translation for the active minutes toggle, adjust previous translations for charts to use `minute` time unit
