### PR TITLE
fix: Auto navigate the project list when all projects in current page are finished

### DIFF
--- a/frontend/components/project/ProjectList.vue
+++ b/frontend/components/project/ProjectList.vue
@@ -3,6 +3,7 @@
     :value="value"
     :headers="headers"
     :items="items"
+    :page.sync="page"
     :options.sync="options"
     :server-items-length="total"
     :search="search"
@@ -63,6 +64,10 @@ export default Vue.extend({
       type: Boolean,
       default: false,
       required: true
+    },
+    page: {
+      type: Number,
+      default: 1
     },
     items: {
       type: Array as PropType<ProjectDTO[]>,

--- a/frontend/components/project/ProjectList.vue
+++ b/frontend/components/project/ProjectList.vue
@@ -19,6 +19,7 @@
     item-key="id"
     :show-select="showSelect"
     @input="$emit('input', $event)"
+    @update:page="$emit('navigation', $event)"
   >
     <template #top>
       <v-text-field

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -37,6 +37,7 @@
       :total="projects.count"
       :show-select="isStaff"
       @update:query="updateQuery"
+      @navigation="setPageNumber"
     />
     <p v-if="!isStaff" class="warning-text">
       {{ $t('generic.onlyDisplayCompletedProject', { number: projects.items.length }) }}
@@ -150,6 +151,7 @@ export default Vue.extend({
     async getProjectData() {
       this.isLoading = true
       const projects = await this.$services.project.list(this.$route.query)
+      const isEmptyProjectList = projects.items.length === 0
       if (this.isStaff) {
         this.projects = _.cloneDeep(projects)
       } else {
@@ -176,10 +178,11 @@ export default Vue.extend({
       const hasFinishedAll = this.projects.items.length === 0
       this.setProject({ hasFinishedAll })
       await this.checkQuestionnaire()
-      if (hasFinishedAll) {
+      if (hasFinishedAll && !isEmptyProjectList) {
         this.page = this.page + 1
+      } else {
+        this.isLoading = false
       }
-      this.isLoading = false
     },
 
     async checkQuestionnaire() {
@@ -207,6 +210,12 @@ export default Vue.extend({
 
     updateQuery(query: object) {
       this.$router.push(query)
+    },
+
+    setPageNumber(pageNumber: number) {
+      if (!this.isLoading && this.page !== pageNumber) {
+        this.page = pageNumber
+      }
     }
   }
 })

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -32,6 +32,7 @@
     <project-list
       v-model="selected"
       :items="projects.items"
+      :page="page"
       :is-loading="isLoading"
       :total="projects.count"
       :show-select="isStaff"
@@ -79,6 +80,7 @@ export default Vue.extend({
       showRestingMessage: false,
       restingEndTime: '',
       totalTextsAnnotated: 0,
+      page: 1
     }
   },
 
@@ -174,6 +176,9 @@ export default Vue.extend({
       const hasFinishedAll = this.projects.items.length === 0
       this.setProject({ hasFinishedAll })
       await this.checkQuestionnaire()
+      if (hasFinishedAll) {
+        this.page = this.page + 1
+      }
       this.isLoading = false
     },
 


### PR DESCRIPTION
This PR aims to solve the issue on the user account, where the project list page is showing an empty list if all projects on the current page are already in finished state. Previously, the user has to either navigate manually to the next page(s) to find the next projects, or set the number of visible rows to a higher value.

With this fix, when the current page has an empty list, the project list will automatically navigate to the next page until some unfinished project is found.

Screenshot:
This is the screenshot taken after a user logs in and the project list finishes loading. In this screenshot, the page is automatically navigated to the third page because first and second pages are empty.
<img width="960" alt="ssssss" src="https://user-images.githubusercontent.com/64476430/217209053-5034145e-9ff2-4b16-8968-bcab07f67fb0.PNG">

What's changed:
 - frontend/components/project/ProjectList.vue : Use the `page.sync` prop on vue data table to alter the current page, use the `@update:page` event to sync the page data in the case of manual navigation by the user by clicking pagination buttons
 - frontend/pages/projects/index.vue : Automatically navigate to the next page when current page contains only finished projects, add `setPageNumber` method to sync the page data in the case of manual navigation