### PR TITLE
fix: Solve issue with jumpy scrolling on annotation page

### DIFF
--- a/frontend/components/tasks/toolbar/ToolbarMobile.vue
+++ b/frontend/components/tasks/toolbar/ToolbarMobile.vue
@@ -22,6 +22,14 @@ export default Vue.extend({
       type: Number,
       default: 1,
       required: true
+    },
+    disablePrev: {
+      type: Boolean,
+      default: false
+    },
+    disableNext: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -38,10 +46,10 @@ export default Vue.extend({
       return parseInt(this.$route.query.page, 10)
     },
     isFirstPage(): boolean {
-      return this.page === 1
+      return this.page === 1 || this.disablePrev
     },
     isLastPage(): boolean {
-      return this.page === this.total || this.total === 0
+      return this.page === this.total || this.total === 0 || this.disableNext
     }
   },
 

--- a/frontend/i18n/de/projects/annotation/sidebar.js
+++ b/frontend/i18n/de/projects/annotation/sidebar.js
@@ -1,5 +1,6 @@
 export default {
     progress: {
+        toggle: 'Fortschrittsbalken umschalten',
         title: 'Fortschritt',
         total: 'Gesamt Texte',
         complete: 'Abgeschlossene Texte'

--- a/frontend/i18n/en/projects/annotation/sidebar.js
+++ b/frontend/i18n/en/projects/annotation/sidebar.js
@@ -1,5 +1,6 @@
 export default {
     progress: {
+        toggle: 'Toggle progress bar',
         title: 'Progress',
         total: 'Total Texts',
         complete: 'Completed Texts'

--- a/frontend/i18n/fr/projects/annotation/sidebar.js
+++ b/frontend/i18n/fr/projects/annotation/sidebar.js
@@ -1,5 +1,6 @@
 export default {
     progress: {
+        toggle: 'Basculer la barre de progression',
         title: 'Progrès',
         total: 'Textes Totaux',
         complete: 'Textes Complétés'

--- a/frontend/i18n/pl/projects/annotation/sidebar.js
+++ b/frontend/i18n/pl/projects/annotation/sidebar.js
@@ -1,5 +1,6 @@
 export default {
     progress: {
+        toggle: 'Przełącz pasek postępu',
         title: 'Postęp',
         total: 'Razem tekstów',
         complete: 'Zakończono tekstów'

--- a/frontend/i18n/zh/projects/annotation/sidebar.js
+++ b/frontend/i18n/zh/projects/annotation/sidebar.js
@@ -1,5 +1,6 @@
 export default {
     progress: {
+        toggle: '切换进度条',
         title: '进展',
         total: '总文本',
         complete: '完成的文本'

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -535,24 +535,6 @@ export default {
       this.showProgressBar = !this.showProgressBar
     },
 
-    getDimensionComponentRef() {
-      let dimensionRef = 'summaryInput'
-      if (this.isCombinationMode) {
-        dimensionRef = 'summaryInput'
-      } else if (this.isSummaryMode) {
-        dimensionRef = 'summaryInput'
-      } else if (this.isEmotionsMode) {
-        dimensionRef = 'emotionsInput'
-      } else if (this.isOthersMode) {
-        dimensionRef = 'othersInput'
-      } else if (this.isHumorMode) {
-        dimensionRef = 'humorInput'
-      } else if (this.isOffensiveMode) {
-        dimensionRef = 'offensiveInput'
-      }
-      return this.$refs[dimensionRef]
-    },
-
     async checkRestingPeriod() {
       const restingEndTime = await this.calculateRestingPeriod()
       if (restingEndTime === null) {

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -88,19 +88,23 @@
             :disable-next="!canNavigateForward"
             class="d-flex d-sm-none header-toolbar --mobile"
           />
-          <v-row>
-            <v-col cols="12" md="9">
-              <p ref="entityText" class="header-text">
-                {{ doc.text }}
-              </p>
-            </v-col>
-            <v-col cols="12" md="3" class="d-sm-none d-md-block text-center">
-              <v-btn class="btn-toggle" plain x-small color="info" @click="toggleProgressBar">
-                {{ $t('annotation_sidebar.progress.toggle') }}
-              </v-btn>
-              <annotation-progress :class="(showProgressBar)?'d-block':'d-none'" :progress="progress" />
-            </v-col>
-          </v-row>
+          <v-card>
+            <v-card-text>
+              <v-row>
+                <v-col cols="12" md="9">
+                  <p ref="entityText" class="header-text">
+                    {{ doc.text }}
+                  </p>
+                </v-col>
+                <v-col cols="12" md="3" class="d-sm-none d-md-block text-center">
+                  <v-btn class="btn-toggle" plain x-small color="info" @click="toggleProgressBar">
+                    {{ $t('annotation_sidebar.progress.toggle') }}
+                  </v-btn>
+                  <annotation-progress :class="(showProgressBar)?'d-block':'d-none'" :progress="progress" />
+                </v-col>
+              </v-row>
+            </v-card-text>
+          </v-card>
         </div>
       </template>
       <template #content>
@@ -1030,7 +1034,7 @@ export default {
     &__header {
       &.--sticky {
         position: sticky;
-        padding: 20px;
+
         top: 55px;
         z-index: 1;
       }

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -82,7 +82,12 @@
           >
             <v-spacer />
           </toolbar-laptop>
-          <toolbar-mobile :total="docs.count" class="d-flex d-sm-none header-toolbar --mobile" />
+          <toolbar-mobile
+            :total="docs.count"
+            :disable-prev="!canNavigateBackward"
+            :disable-next="!canNavigateForward"
+            class="d-flex d-sm-none header-toolbar --mobile"
+          />
           <v-row>
             <v-col cols="12" md="9">
               <p ref="entityText" class="header-text">
@@ -90,7 +95,9 @@
               </p>
             </v-col>
             <v-col cols="12" md="3" class="d-sm-none d-md-block text-center">
-              <v-btn plain x-small @click="toggleProgressBar">{{ $t('annotation_sidebar.progress.toggle') }}</v-btn>
+              <v-btn class="btn-toggle" plain x-small color="info" @click="toggleProgressBar">
+                {{ $t('annotation_sidebar.progress.toggle') }}
+              </v-btn>
               <annotation-progress :class="(showProgressBar)?'d-block':'d-none'" :progress="progress" />
             </v-col>
           </v-row>
@@ -1053,6 +1060,12 @@ export default {
         max-height: 150px;
         overflow-y: auto;
         opacity: 0.8;
+      }
+
+      .btn-toggle {
+        white-space: normal;
+        word-wrap: break-word;
+        text-decoration: underline;
       }
     }
   }


### PR DESCRIPTION
This PR aims to solve the issue with jumpy scrolling behavior on annotation page. The entity editor component has been removed, and now the document text is displayed as a simple paragraph inside the sticky header. Additionally,
 1. A toggle is added to hide/show the progress bar (hiding the progress bar can reduce the area taken by the sticky header).
 2. The navigation buttons in toolbar mobile are now disabled accordingly. Previously, in mobile view, user can still navigate with prev and next buttons, even though they can't confirm any annotation because the confirm button is not available in mobile view. Now the navigation behavior is similar to the desktop view.

Screenshots:
<img width="960" alt="prA" src="https://user-images.githubusercontent.com/64476430/217239832-5e3806ee-b0f8-4d75-bb79-ea1e094cb3a0.PNG">
<img width="960" alt="prB" src="https://user-images.githubusercontent.com/64476430/217239836-5d8ae898-92b7-48f7-934e-94c422f255ac.PNG">

What's changed:
 - frontend/pages/projects/_id/affective-annotation/index.vue : Remove entity editor, remove the onscroll listener for dynamically toggling sticky and hiding the entity editor (now the header is always sticky), add toggle for hiding/showing progress bar
 - frontend/components/tasks/toolbar/ToolbarMobile.vue : Add props to conditionally disable prev and next buttons in mobile view
 - frontend/i18n/* : Add translations for the progress bar toggle label