### PR TITLE
Fix: Project list not showing the next project for annotator (stuck at project 20th)

### DIFF
--- a/backend/projects/views/project.py
+++ b/backend/projects/views/project.py
@@ -26,7 +26,7 @@ class ProjectList(generics.ListCreateAPIView):
         return super().get_permissions()
 
     def get_queryset(self):
-        return Project.objects.filter(role_mappings__user=self.request.user)
+        return Project.objects.filter(role_mappings__user=self.request.user).order_by("created_at")
 
     def perform_create(self, serializer):
         project = serializer.save(created_by=self.request.user)

--- a/backend/projects/views/project.py
+++ b/backend/projects/views/project.py
@@ -58,7 +58,7 @@ class ProjectProgressDetail(generics.RetrieveAPIView):
     permission_classes = [IsAuthenticated & (IsProjectAdmin | IsProjectStaffAndReadOnly)]
 
     def get(self, request, *args, **kwargs):
-        all_projects = Project.objects.filter(role_mappings__user=self.request.user)
+        all_projects = Project.objects.filter(role_mappings__user=self.request.user).order_by("created_at")
         all_project_data = []
         for project in all_projects:
             examples = Example.objects.filter(project=project.id).values("id")


### PR DESCRIPTION
Hello, this PR aims to solve the problem stated by user `2828` of project list shows blank page after finished project 20th (named `data_part_19_Affective_Annotation`). As I commented on PR #86 from Teddy, the navigation is not the root of this issue.

It can be seen in this picture, I navigated it manually to 3rd and the project list appear. However, it doesn't show any clickable project which was the user's problem. And the next clickable project should be project named `data_part_20_Affective_Annotation` (because it's the 21st project) but it wasn't shown, even I navigated every page until the end.
![WhatsApp Image 2023-02-07 at 15 47 29](https://user-images.githubusercontent.com/17596118/217398189-5387cd23-5312-4bf4-9938-d861632d8c71.jpeg)

This project was shown when I searched its name as in this pic or set the number of row to 50 as dr Kocon said:
![image](https://user-images.githubusercontent.com/17596118/217398735-3d14f0f6-11fe-4d14-bb1a-50b52d562096.png)

The reason for this issue is from the project list's API when using `offset`, somehow it messed the order of project list, which lead to the problem that there's no project `data_part_20_Affective_Annotation` appear in the next page.

So now, current issue is:
- With `offset=0` or `offset=10`, the order of project is ok (that's why there's no feedback about that bug until this project)
- After `offset=20` and so on, there's the problem I mentioned above.
- But, this behaviour doesn't happen on my local environment. I dump the latest backup database, as well as using the same code version as the instance, but in my local env, the project list is in order. I have discussed with Teddy and Argi and it seems that Teddy's local env is the same as mine. Here's an example of making request to the project list API on the instance vs on my local:
(Request to instance - `http://doccano.clarin-pl.eu/v1/projects?limit=10&offset=20`)
```
{
    "count": 119,
    "next": "http://doccano.clarin-pl.eu/v1/projects?limit=10&offset=30",
    "previous": "http://doccano.clarin-pl.eu/v1/projects?limit=10&offset=10",
    "results": [
        {
            "id": 33,
            "name": "data_part_17_AffectiveAnnotation",
            "description": "Affective Annotation Multi-dimension mode",
            "guideline": "",
            "project_type": "AffectiveAnnotation",
            "updated_at": "2022-11-30T21:50:41.226712Z",
          ....
        },
        {
            "id": 37,
            "name": "data_part_21_AffectiveAnnotation",
            "description": "Affective Annotation Multi-dimension mode",
            "guideline": "",
            "project_type": "AffectiveAnnotation",
            "updated_at": "2022-11-30T21:54:41.947575Z",
            "random_order": false,
            "created_by": 3,
            ....
        },
        {
            "id": 45,
            "name": "data_part_29_AffectiveAnnotation",
            "description": "Affective Annotation Multi-dimension mode",
            "guideline": "",
            "project_type": "AffectiveAnnotation",
            "updated_at": "2022-11-30T22:02:48.705484Z",
            "random_order": false,
            "created_by": 3,
           ....
        },
```

(Request to my local env `http://localhost/v1/projects?limit=10&offset=20`)
```
{
    "count": 119,
    "next": "http://localhost/v1/projects?limit=10&offset=30",
    "previous": "http://localhost/v1/projects?limit=10&offset=10",
    "results": [
        {
            "id": 36,
            "name": "data_part_20_AffectiveAnnotation",
            "description": "Affective Annotation Multi-dimension mode",
            "guideline": "",
            "project_type": "AffectiveAnnotation",
            "updated_at": "2022-11-30T21:53:41.961434Z",
            "random_order": false,
            "created_by": 3,
            .... 
        },
        {
            "id": 37,
            "name": "data_part_21_AffectiveAnnotation",
            "description": "Affective Annotation Multi-dimension mode",
            "guideline": "",
            "project_type": "AffectiveAnnotation",
            "updated_at": "2022-11-30T21:54:41.947575Z",
            "random_order": false,
            "created_by": 3,
             ....
        },
        {
            "id": 38,
            "name": "data_part_22_AffectiveAnnotation",
            "description": "Affective Annotation Multi-dimension mode",
            "guideline": "",
            "project_type": "AffectiveAnnotation",
            "updated_at": "2022-11-30T21:55:43.035707Z",
            "random_order": false,
            "created_by": 3,
            ....
        },
        {
            "id": 39,
            "name": "data_part_23_AffectiveAnnotation",
            "description": "Affective Annotation Multi-dimension mode",
            "guideline": "",
            "project_type": "AffectiveAnnotation",
            "updated_at": "2022-11-30T21:56:44.549975Z",
            "random_order": false,
            "created_by": 3,
            ...
        },
```

So the solution I came up with now is just forcing the results of project list API were ordered by `created_at`. However, to be honest this issue is really weird because my local env can't reproduce that issue, even using same dtb, same deployment. So without making the changes in the instance I can't be sure that it will solve the problem.

