### PR TITLE
fix: Solve 404 error in user (annotator) account after logging in

### DIFF
--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -177,10 +177,10 @@ export default Vue.extend({
       }
       const hasFinishedAll = this.projects.items.length === 0
       this.setProject({ hasFinishedAll })
-      await this.checkQuestionnaire()
       if (hasFinishedAll && !isEmptyProjectList) {
         this.page = this.page + 1
       } else {
+        await this.checkQuestionnaire()
         this.isLoading = false
       }
     },


### PR DESCRIPTION
During recent development, I encountered an issue inside some user (annotator) accounts, where after logging in we get a 404 error:
![bug-before](https://user-images.githubusercontent.com/64476430/220583268-7b98b062-2cd9-47a4-bbc7-655fe3aa945d.gif)

Previously it didn't happen during testing. Now I have identified that the issue happens within an account that already has a lot of annotations made. It is caused by PR #86, which is only recently merged, so it didn't affect the pilot study.

The issue is that, with the auto navigation mechanism, every time the project list datatable changes page, it calls `getProjectData()`, which in turn always calls `checkQuestionnaire()`. Now with the fix, `checkQuestionnaire()` is called only after the auto navigation has finished:
![bug-after](https://user-images.githubusercontent.com/64476430/220585868-44f7e587-d29b-4260-90b5-4bc71c3fc1c6.gif)

What's Changed:
 - frontend/pages/projects/index.vue: Call `checkQuestionnaire()` only after the auto navigation has finished working