### PR TITLE
feat: Connect API endpoints for dynamic dimensions between BE and FE

### DIFF
--- a/backend/projects/urls.py
+++ b/backend/projects/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
 from .views.member import MemberDetail, MemberList, MyRole
-from .views.project import ProjectDetail, ProjectList, ProjectProgressDetail
+from .views.project import ProjectDetail, ProjectList, ProjectProgressDetail, ProjectDimensionDetail
 from .views.tag import TagDetail, TagList
+
 
 urlpatterns = [
     path(route="projects", view=ProjectList.as_view(), name="project_list"),
@@ -13,4 +14,5 @@ urlpatterns = [
     path(route="projects/<int:project_id>/tags/<int:tag_id>", view=TagDetail.as_view(), name="tag_detail"),
     path(route="projects/<int:project_id>/members", view=MemberList.as_view(), name="member_list"),
     path(route="projects/<int:project_id>/members/<int:member_id>", view=MemberDetail.as_view(), name="member_detail"),
+    path(route="projects/<int:project_id>/dimension-detail", view=ProjectDimensionDetail.as_view(), name="project_dimension_detail"),
 ]

--- a/frontend/domain/models/dimension/dimension.ts
+++ b/frontend/domain/models/dimension/dimension.ts
@@ -1,0 +1,31 @@
+import 'reflect-metadata'
+
+export class DimensionItem {
+  constructor(
+    public id: number,
+    public name: string,
+    public type: string,
+    public metadata: string
+  ) {}
+
+  toObject(): Object {
+    return {
+      id: this.id,
+      name: this.name,
+      type: this.type,
+      metadata: this.metadata
+    }
+  }
+}
+
+export class DimensionItemList {
+  constructor(
+    public items: DimensionItem[]
+  ) {}
+
+  toObject(): Object {
+    return {
+      items: this.items
+    }
+  }
+}

--- a/frontend/domain/models/dimension/dimensionRepository.ts
+++ b/frontend/domain/models/dimension/dimensionRepository.ts
@@ -1,0 +1,9 @@
+import { DimensionItem, DimensionItemList } from '~/domain/models/dimension/dimension'
+
+export interface DimensionRepository {
+    list(projectId: string): Promise<DimensionItemList>
+    listAllDimensions(): Promise<DimensionItemList>
+    getDimensionMetaData(dimensionId: number): Promise<string>
+    assignDimensions(projectId: string, dimensionIds: number[]): Promise<void>
+    create(projectId: string, name: string, type: string, dimension_meta_data: string): Promise<DimensionItem>
+}

--- a/frontend/middleware/check-admin.js
+++ b/frontend/middleware/check-admin.js
@@ -6,6 +6,11 @@ export default _.debounce(async function ({ app, store, route, redirect }) {
   } catch (e) {
     redirect('/projects')
   }
+  try {
+    await store.dispatch('projects/setCurrentDimensions', route.params.id)
+  } catch (e) {
+    redirect('/projects')
+  }
   const isProjectAdmin = await app.$services.member.isProjectAdmin(route.params.id)
   const projectRoot = app.localePath('/projects/' + route.params.id)
   const path = route.fullPath.replace(/\/$/g, '')

--- a/frontend/middleware/set-project.js
+++ b/frontend/middleware/set-project.js
@@ -3,5 +3,6 @@ export default async function ({ store, route }) {
   const isEmpty = Object.keys(project).length === 0 && project.constructor === Object
   if (isEmpty) {
     await store.dispatch('projects/setCurrentProject', route.params.id)
+    await store.dispatch('projects/setCurrentDimensions', route.params.id)
   }
 }

--- a/frontend/plugins/services.ts
+++ b/frontend/plugins/services.ts
@@ -50,6 +50,8 @@ import { QuestionnaireApplicationService}  from "~/services/application/question
 import { APIQuestionnaireRepository } from '~/repositories/questionnaire/apiQuestionnaireRepository'
 import { StatisticsApplicationService } from '~/services/application/statistics/statisticsApplicationService'
 import { APIStatisticsRepository } from '~/repositories/statistics/apiStatistics'
+import { DimensionApplicationService } from '~/services/application/dimension/dimensionApplicationServices'
+import { APIDimensionRepository } from '~/repositories/dimension/apiDimensionRepository'
 
 export interface Services {
   categoryType: LabelApplicationService
@@ -80,6 +82,7 @@ export interface Services {
   affectiveScale: AffectiveScaleApplicationService
   questionnaire: QuestionnaireApplicationService
   statistics: StatisticsApplicationService
+  dimension: DimensionApplicationService
 }
 
 declare module 'vue/types/vue' {
@@ -114,6 +117,7 @@ const plugin: Plugin = (_, inject) => {
   const affectiveScaleRepository = new APIAffectiveScaleRepository()
   const questionnaireRepository = new APIQuestionnaireRepository()
   const statisticsRepository = new APIStatisticsRepository()
+  const dimensionRepository = new APIDimensionRepository()
 
   const categoryType = new LabelApplicationService(new APILabelRepository('category-type'))
   const spanType = new LabelApplicationService(new APILabelRepository('span-type'))
@@ -146,6 +150,7 @@ const plugin: Plugin = (_, inject) => {
   const affectiveScale = new AffectiveScaleApplicationService(affectiveScaleRepository)
   const questionnaire = new QuestionnaireApplicationService(questionnaireRepository)
   const statistics = new StatisticsApplicationService(statisticsRepository)
+  const dimension = new DimensionApplicationService(dimensionRepository)
 
   const services: Services = {
     categoryType,
@@ -175,7 +180,8 @@ const plugin: Plugin = (_, inject) => {
     affectiveTextlabel,
     affectiveScale,
     questionnaire,
-    statistics
+    statistics,
+    dimension
   }
   inject('services', services)
 }

--- a/frontend/repositories/dimension/apiDimensionRepository.ts
+++ b/frontend/repositories/dimension/apiDimensionRepository.ts
@@ -1,0 +1,61 @@
+import ApiService from '@/services/api.service'
+import { DimensionRepository } from '~/domain/models/dimension/dimensionRepository'
+import { DimensionItem, DimensionItemList } from '~/domain/models/dimension/dimension'
+
+export class APIDimensionRepository implements DimensionRepository {
+  constructor(private readonly request = ApiService) {}
+
+  async list(projectId: string): Promise<DimensionItemList> {
+    const url = `/projects/${projectId}/dimension-detail`
+    const response = await this.request.get(url)
+    const dimensions = response.data.map(
+      function(item: any) {
+        const dimension_meta_data = item.dimension_meta_data
+        for (let idx = 0; idx < dimension_meta_data.length; idx++) {
+          dimension_meta_data[idx].config.with_checkbox = !!dimension_meta_data[idx].config.with_checkbox
+          dimension_meta_data[idx].config.is_multiple_answers = !!dimension_meta_data[idx].config.is_multiple_answers
+        }
+        return new DimensionItem(item.id, item.name, item.type, dimension_meta_data)
+      }
+    )
+    return new DimensionItemList(dimensions)
+  }
+
+  async listAllDimensions(): Promise<DimensionItemList> {
+    const url = `/projects/dimensions`
+    const response = await this.request.get(url)
+    const dimensions = response.data.map(
+      function(item: any) {
+        const dimension_meta_data = item.dimension_meta_data
+        for (let idx = 0; idx < dimension_meta_data.length; idx++) {
+          dimension_meta_data[idx].config.with_checkbox = !!dimension_meta_data[idx].config.with_checkbox
+          dimension_meta_data[idx].config.is_multiple_answers = !!dimension_meta_data[idx].config.is_multiple_answers
+        }
+        return new DimensionItem(item.id, item.name, item.type, dimension_meta_data)
+      }
+    )
+    return new DimensionItemList(dimensions)
+  }
+
+  async getDimensionMetaData(dimensionId: number): Promise<string> {
+    const url = `/projects/dimensions/${dimensionId}/metadata`
+    const response = await this.request.get(url)
+    const dimension_meta_data = response.data
+    for (let idx = 0; idx < dimension_meta_data.length; idx++) {
+      dimension_meta_data[idx].config.with_checkbox = !!dimension_meta_data[idx].config.with_checkbox
+      dimension_meta_data[idx].config.is_multiple_answers = !!dimension_meta_data[idx].config.is_multiple_answers
+    }
+    return dimension_meta_data
+  }
+
+  async assignDimensions(projectId: string, dimensionIds: number[]): Promise<void> {
+    const url = `/projects/${projectId}/assign_dimensions`
+    await this.request.post(url, { "dimension": dimensionIds })
+  }
+
+  async create(projectId: string, name: string, type: string, dimension_meta_data: string): Promise<DimensionItem> {
+    const url = `/projects/${projectId}/dimensions`
+    const response = await this.request.post(url, { name, type, dimension_meta_data })
+    return new DimensionItem(response.data.id, response.data.name, response.data.type, response.data.dimension_meta_data)
+  }
+}

--- a/frontend/services/application/dimension/dimensionApplicationServices.ts
+++ b/frontend/services/application/dimension/dimensionApplicationServices.ts
@@ -1,0 +1,26 @@
+import { DimensionRepository } from '~/domain/models/dimension/dimensionRepository'
+import { DimensionItem, DimensionItemList } from '~/domain/models/dimension/dimension'
+
+export class DimensionApplicationService {
+  constructor(private readonly repository: DimensionRepository) {}
+
+  public async list(projectId: string): Promise<DimensionItemList> {
+    return await this.repository.list(projectId)
+  }
+
+  public async listAllDimensions(): Promise<DimensionItemList> {
+    return await this.repository.listAllDimensions()
+  }
+
+  public async getDimensionMetaData(dimensionId: number): Promise<string> {
+    return await this.repository.getDimensionMetaData(dimensionId)
+  }
+
+  public async assignDimensions(projectId: string, dimensionIds: number[]): Promise<void> {
+    return await this.repository.assignDimensions(projectId, dimensionIds)
+  }
+
+  public async create(projectId: string, name: string, type: string, metadata: string): Promise<DimensionItem> {
+    return await this.repository.create(projectId, name, type, metadata)
+  }
+}

--- a/frontend/store/projects.js
+++ b/frontend/store/projects.js
@@ -1,5 +1,6 @@
 export const state = () => ({
-  current: {}
+  current: {},
+  currentDimensions: {}
 })
 
 export const getters = {
@@ -15,12 +16,18 @@ export const getters = {
   },
   getLink(state) {
     return state.current.pageLink
+  },
+  currentDimensions(state) {
+    return state.currentDimensions
   }
 }
 
 export const mutations = {
   setCurrent(state, payload) {
     state.current = payload
+  },
+  setCurrentDimensions(state, payload) {
+    state.currentDimensions = payload
   }
 }
 
@@ -33,4 +40,12 @@ export const actions = {
       throw new Error(error)
     }
   },
+  async setCurrentDimensions({ commit }, projectId) {
+    try {
+      const response = await this.$services.dimension.list(projectId)
+      commit('setCurrentDimensions', response)
+    } catch (error) {
+      throw new Error(error)
+    }
+  }
 }


### PR DESCRIPTION
This PR aims to connect the new API endpoints for dynamic dimensions added in PR #94 to the front-end. In addition, it also adds the API endpoint for listing all dimensions and their metadata for a given project. Ideally, this PR should not be merged before PR #94 is merged, as it is dependant on the BE implementation.

What's new/changed:
 - backend/projects/views/project.py : Add view for listing dimensions and their metadata for a given project
 - backend/projects/urls.py : Add api endpoint for listing dimensions and their metadata for a given project
 - frontend/domain/models/dimension/dimension.ts : Add classes for dimension and dimension list
 - frontend/domain/models/dimension/dimensionRepository.ts : Add dimension repository
 - frontend/repositories/dimension/apiDimensionRepository.ts : Add new api endpoints
 - frontend/services/application/dimension/dimensionApplicationServices.ts : Add dimension application service containing new api endpoints related with dynamic dimensions
 - frontend/plugins/services.ts : Register the new dimension application service
 - frontend/store/projects.js : Add getter and setter to store dimensions data of currently opened project
 - frontend/middleware/check-admin.js : Call the dimension setter after setting current project
 - frontend/middleware/set-project.js : Call the dimension setter after setting current project

Notes:
 1. The api endpoint for creating new project hasn't been modified to include the new dynamic dimension project type, as I'm not sure if it's been done in the FE implementation or not. It can be done in this PR if needed.
 2. For creating new dimensions (the api endpoint `/v1/projects/<int:project_id>/dimensions`), it can be done from FE via `this.$services.dimension.create(projectId: string, name: string, type: string, dimension_meta_data: string)`.
 3. For getting metadata of a given dimension (the api endpoint `/v1/projects/dimensions/<int:dimension_id>/metadata`), it can be done from FE via `this.$services.dimension.getDimensionMetaData(dimensionId: number)`.
 4. For getting all dimensions (the api endpoint `/v1/projects/dimensions`, it can be done from FE via `this.$services.dimension.listAllDimensions()`.
 5. For assigning additional dimensions to a project (the api endpoint `/v1/projects/<int:project_id>/assign_dimensions`), it can be done from FE via `this.$services.dimension.assignDimensions(projectId: string, dimensionIds: number[])`.
 6. For getting a list of dimensions and their metadata for a project, it can be retrieved from the `project` store with `currentDimensions` getter. The store is populated and updated by middleware, which calls the api endpoint with `this.$services.dimension.list(projectId)`.

For testing, the branch `feature/DynamicAnnotationProject-api-integrationTest` can be used, which contains the code for the BE implementation and the code from this PR.