### PR TITLE
feat: Add test scripts for dynamic annotation project type

### DIFF
--- a/backend/data_export/tests/test_catalog.py
+++ b/backend/data_export/tests/test_catalog.py
@@ -9,7 +9,8 @@ from projects.models import (
     SEQUENCE_LABELING,
     SPEECH2TEXT,
     ARTICLE_ANNOTATION,
-    AFFECTIVE_ANNOTATION
+    AFFECTIVE_ANNOTATION,
+    DYNAMIC_ANNOTATION
 )
 
 
@@ -24,6 +25,7 @@ class TestOptions(unittest.TestCase):
             SPEECH2TEXT,
             ARTICLE_ANNOTATION,
             AFFECTIVE_ANNOTATION,
+            DYNAMIC_ANNOTATION,
         ]
         for task in tasks:
             with self.subTest(task=task):

--- a/backend/data_import/tests/data/dynamic_annotation/example.json
+++ b/backend/data_import/tests/data/dynamic_annotation/example.json
@@ -1,0 +1,41 @@
+[
+    {
+        "text": "Stół z powyłamywanymi nogami",
+        "scale": [[1, "happy"], [4, "sadness"], [2, "negative"]],
+        "label": ["I dont know"],
+        "meta": {
+            "article_title": "10 Craziest Polish Tongue Twisters",
+            "publish_datetime": "2022-08-01 13:59:59",
+            "crawled_datetime": "2022-09-05 08:12:45"
+        },
+        "article_id": "8eabas8s5pveszg917vm1357",
+        "order": 5,
+        "type": "subheader"
+    },
+    {
+        "text": "W Szczebrzeszynie chrząszcz brzmi w trzcinie.",
+        "scale": [[1, "sorrow"], [3, "sadness"], [2, "positive"]],
+        "label": ["happy"],
+        "meta": {
+            "article_title": "10 Craziest Polish Tongue Twisters",
+            "publish_datetime": "2022-08-01 13:59:59",
+            "crawled_datetime": "2022-09-05 08:12:45"
+        },
+        "article_id": "8eabas8s5pveszg917vm1357",
+        "order": 10,
+        "type": "subheader"
+    },
+    {
+        "text": "Nowa generacja biosensora pozwoli na bieżąco analizować próbki potu",
+        "scale": [[1, "sorrow"], [5, "sadness"], [2, "positive"]],
+        "label": [["happy", "Jakimi słowami opisałbyś ten tekst (tagi, słowa kluczowe)"], ["funny", "Jakie wrażenia/emocje/odczucia wzbudza w Tobie ten tekst?"]],
+        "meta": {
+            "article_title": "10 Craziest Polish Tongue Twisters",
+            "publish_datetime": "2022-08-01 13:59:59",
+            "crawled_datetime": "2022-09-05 08:12:45"
+        },
+        "article_id": "8eabas8s5pveszg917vm1357",
+        "order": 19,
+        "type": "subheader"
+    }
+]

--- a/backend/data_import/tests/test_catalog.py
+++ b/backend/data_import/tests/test_catalog.py
@@ -10,6 +10,7 @@ from projects.models import (
     SPEECH2TEXT,
     ARTICLE_ANNOTATION,
     AFFECTIVE_ANNOTATION,
+    DYNAMIC_ANNOTATION
 )
 
 
@@ -24,6 +25,7 @@ class TestOptions(unittest.TestCase):
             SPEECH2TEXT,
             ARTICLE_ANNOTATION,
             AFFECTIVE_ANNOTATION,
+            DYNAMIC_ANNOTATION,
         ]
         for task in tasks:
             with self.subTest(task=task):

--- a/backend/projects/tests/test_dimension.py
+++ b/backend/projects/tests/test_dimension.py
@@ -1,0 +1,111 @@
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from api.tests.utils import CRUDMixin
+from projects.tests.utils import make_dimension, make_dimension_meta_data, make_project_dimension, prepare_project
+from users.tests.utils import make_user
+
+
+class TestDimension(CRUDMixin):
+    @classmethod
+    def setUpTestData(cls):
+        cls.project = prepare_project(task="DynamicAnnotation")
+        cls.non_member = make_user()
+        cls.url = reverse(viewname="dynamic_dimension_list", args=[cls.project.item.id])
+        cls.data = {
+            "name": "example_dimension",
+            "type": "slider",
+            "dimension_meta_data": [
+                {
+                    "codename": "DIM_NEW_EMO_0123",
+                    "config": {"slider_min": 0, "slider_max": 100, "slider_step": 10, "with_checkbox": False, "minVal_description": "Wcale", "maxVal_description": "W pełni"},
+                    "required": True,
+                    "readonly": False
+                }
+            ]
+        }
+
+    def test_allows_admin_to_create_dimension(self):
+        response = self.assert_create(self.project.admin, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], self.data["name"])
+        self.assertEqual(response.data["type"], self.data["type"])
+        self.assertEqual(response.data["dimension_meta_data"][0]["codename"], self.data["dimension_meta_data"][0]["codename"])
+
+    def test_denies_project_staff_to_create_dimension(self):
+        for member in self.project.staffs:
+            self.assert_create(member, status.HTTP_403_FORBIDDEN)
+
+    def test_denies_unauthenticated_user_to_create_dimension(self):
+        self.assert_create(expected=status.HTTP_403_FORBIDDEN)
+
+    def test_return_all_dimensions_to_member(self):
+        # should return 69 default dims
+        for member in self.project.members:
+            response = self.assert_fetch(member, status.HTTP_200_OK)
+            self.assertEqual(len(response.data), 69)
+        # should return 70 dims, which are 69 default dims and 1 created dim
+        self.assert_create(self.project.admin, status.HTTP_201_CREATED)
+        for member in self.project.members:
+            response = self.assert_fetch(member, status.HTTP_200_OK)
+            self.assertEqual(len(response.data), 70)
+
+
+class TestProjectDimensionList(CRUDMixin):
+    @classmethod
+    def setUpTestData(cls):
+        cls.project = prepare_project(task="DynamicAnnotation")
+        cls.non_member = make_user()
+        cls.dynamic_dimension = make_dimension()
+        make_project_dimension(project=cls.project.item, dimension=cls.dynamic_dimension)
+        cls.url = reverse(viewname="project_dimension_detail", args=[cls.project.item.id])
+
+    def test_return_dimensions_to_member(self):
+        for member in self.project.members:
+            response = self.assert_fetch(member, status.HTTP_200_OK)
+            self.assertEqual(len(response.data), 1)
+
+    def test_does_not_return_dimensions_to_non_member(self):
+        self.assert_fetch(self.non_member, status.HTTP_403_FORBIDDEN)
+
+    def test_does_not_return_dimensions_to_unauthenticated_user(self):
+        self.assert_fetch(expected=status.HTTP_403_FORBIDDEN)
+
+
+class TestDimensionMetaDataList(CRUDMixin):
+    @classmethod
+    def setUpTestData(cls):
+        cls.project = prepare_project(task="DynamicAnnotation")
+        cls.non_member = make_user()
+        cls.dynamic_dimension = make_dimension()
+        make_dimension_meta_data(dimension=cls.dynamic_dimension)
+        cls.url = reverse(viewname="dimension_metadata_list", args=[cls.dynamic_dimension.id])
+
+    def test_return_dimension_meta_data_to_member(self):
+        for member in self.project.members:
+            response = self.assert_fetch(member, status.HTTP_200_OK)
+            self.assertEqual(len(response.data), 1)
+
+    def test_does_not_return_dimension_meta_data_to_unauthenticated_user(self):
+        self.assert_fetch(expected=status.HTTP_403_FORBIDDEN)
+
+
+class TestAssignProjectDimensions(CRUDMixin):
+    @classmethod
+    def setUpTestData(cls):
+        cls.project = prepare_project(task="DynamicAnnotation")
+        cls.non_member = make_user()
+        cls.url = reverse(viewname="add_project_dimension", args=[cls.project.item.id])
+        cls.data = {
+            "dimension": [1, 2, 3]
+        }
+
+    def test_allows_admin_to_assign_dimension(self):
+        response = self.assert_create(self.project.admin, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["dimension"], self.data["dimension"])
+
+    def test_denies_project_staff_to_assign_dimension(self):
+        for member in self.project.staffs:
+            self.assert_create(member, status.HTTP_403_FORBIDDEN)
+
+    def test_denies_unauthenticated_user_to_assign_dimension(self):
+        self.assert_create(expected=status.HTTP_403_FORBIDDEN)

--- a/backend/projects/tests/utils.py
+++ b/backend/projects/tests/utils.py
@@ -12,6 +12,7 @@ from projects.models import (
     SPEECH2TEXT,
     ARTICLE_ANNOTATION,
     AFFECTIVE_ANNOTATION,
+    DYNAMIC_ANNOTATION,
     Member,
     Role,
 )
@@ -72,6 +73,7 @@ def make_project(task: str, users: List[str], roles: List[str], collaborative_an
         INTENT_DETECTION_AND_SLOT_FILLING: "IntentDetectionAndSlotFillingProject",
         ARTICLE_ANNOTATION: "ArticleAnnotationProject",
         AFFECTIVE_ANNOTATION: "AffectiveAnnotationProject",
+        DYNAMIC_ANNOTATION: "DynamicAnnotationProject",
     }.get(task, "Project")
     project = mommy.make(
         _model=project_model,
@@ -90,6 +92,18 @@ def make_project(task: str, users: List[str], roles: List[str], collaborative_an
 
 def make_tag(project):
     return mommy.make("Tag", project=project)
+
+
+def make_dimension(name: str = "test_dynamic_dimension", type: str = "checkbox"):
+    return mommy.make("DynamicDimension", name=name, type=type)
+
+
+def make_dimension_meta_data(dimension, codename: str = "test_dimension_meta_data", config: dict = {}, required: bool = True, readonly: bool = False):
+    return mommy.make("DimensionMetaData", dimension=dimension, codename=codename, config=config, required=required, readonly=readonly)
+
+
+def make_project_dimension(project, dimension):
+    return mommy.make("ProjectDimension", project=project, dimension=dimension)
 
 
 def prepare_project(task: str = "Any", collaborative_annotation=False, **kwargs):


### PR DESCRIPTION
This PR includes test scripts for the data export, import, and new API endpoints (dimension creation, dimension list in project, all dimension list, metadata list, and assigning dimension).

Notably, the export and import tests are quite similar to the ones for affective annotation project type, due to the fact that our current export and import formats are similar with the affective annotation project type. I decided to make separate tests anyway in case if in the future the export and import formats for dynamic annotation project type will be modified -- in that case, the tests will be adjusted too.

What's new:
 - backend/data_import/tests/data/dynamic_annotation/example.json : Add data for import test of dynamic annotation project type
 - backend/projects/tests/test_dimension.py : Add tests related with dynamic dimension

What's changed:
 - backend/data_export/tests/test_catalog.py : Add dynamic annotation project type to export test catalog
 - backend/data_export/tests/test_task.py : Add export tests for dynamic annotation in emotion mode, summary mode, others mode
 - backend/data_import/tests/test_catalog.py : Add dynamic annotation project type to import test catalog
 - backend/data_import/tests/test_tasks.py : Add import tests for dynamic annotation in emotion mode, summary mode, others mode
 - backend/projects/tests/utils.py : Add additional utility functions for dimension tests
