### PR TITLE
Feat: FE - set checkbox required value based on sliders state 

### DIFF
--- a/frontend/components/questionnaires/form/SliderInput.vue
+++ b/frontend/components/questionnaires/form/SliderInput.vue
@@ -17,7 +17,7 @@
           :min="config.min"
           :max="config.max"
           :readonly="readOnly || isSubmitting"
-          :disabled="disabled"
+          :disabled="readOnly"
           :tick-labels="config.showTickLabels ? tickLabels : []"
           step="1"
           @change="onSliderValueChange"
@@ -47,10 +47,6 @@ export default Vue.extend({
       }
     },
     readOnly: {
-      type: Boolean,
-      default: false
-    },
-    disabled: {
       type: Boolean,
       default: false
     },

--- a/frontend/components/questionnaires/form/SliderInput.vue
+++ b/frontend/components/questionnaires/form/SliderInput.vue
@@ -17,7 +17,7 @@
           :min="config.min"
           :max="config.max"
           :readonly="readOnly || isSubmitting"
-          :disabled="readOnly"
+          :disabled="disabled"
           :tick-labels="config.showTickLabels ? tickLabels : []"
           step="1"
           @change="onSliderValueChange"
@@ -47,6 +47,10 @@ export default Vue.extend({
       }
     },
     readOnly: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
       type: Boolean,
       default: false
     },

--- a/frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue
@@ -88,6 +88,7 @@
                                         :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
                                         :label="$t(`annotation.humor.subquestion3.substatement${(idx+1)}`)"
                                         class="subquestions-item__checkbox"
+                                        hide-details
                                         @change="onLabelChange(substatement, `subquestion3`, idx)" />
 
                                     <textfield-modal
@@ -125,6 +126,7 @@
                                             :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
                                             :label="$t(`annotation.humor.subquestion4.substatement${(idx+1)}`)" 
                                             class="subquestions-item__checkbox"
+                                            hide-details
                                             @change="onLabelChange(substatement, `subquestion4`, idx)"
                                         />
                                     </p>
@@ -469,63 +471,64 @@ export default Vue.extend({
       border: 2px solid red;
     }
   }
-}
 
-.widget {
-  font-size: 0.8rem;
+  .widget {
+    font-size: 0.8rem;
 
-  &__title {
-    font-size: 1rem;
-    font-weight: bold;
-    margin-bottom: 10px;
-  }
-
-  &__questions {
-    padding: none;
-  }
-}
-
-.questions-item {
-  opacity: 0.3;
-
-  &.--visible {
-    opacity: 1;
-  }
-
-  &__slider {
-    display: flex;
-
-    .v-slider__tick-label {
-      font-size: 0.8rem;
+    &__title {
+      font-size: 1rem;
+      font-weight: bold;
+      margin-bottom: 10px;
     }
 
-    .slider-text {
-      color: gray;
-      margin-top: 5px;
-
-      &.--start {
-        margin-right: 10px;
-      }
-
-      &.--end {
-        margin-left: 10px;
-      }
+    &__questions {
+      padding: none;
     }
   }
-}
 
-.subquestions {
-  list-style-type: none;
-  padding: 0;
+  .questions-item {
+    opacity: 0.3;
 
-  &__item {
-    .subquestions-item__checkbox {
-      .v-label {
+    &.--visible {
+      opacity: 1;
+    }
+
+    &__slider {
+      display: flex;
+
+      .v-slider__tick-label {
         font-size: 0.8rem;
       }
 
-      .v-input__slot {
-        margin: 0;
+      .slider-text {
+        color: gray;
+        margin-top: 5px;
+        font-size: 0.8rem;
+
+        &.--start {
+          margin-right: 10px;
+        }
+
+        &.--end {
+          margin-left: 10px;
+        }
+      }
+    }
+  }
+
+  .subquestions {
+    list-style-type: none;
+    padding: 0;
+
+    &__item {
+      .subquestions-item__checkbox {
+        .v-label {
+          font-size: 0.8rem;
+        }
+
+        .v-input__slot {
+          margin: 0;
+        }
       }
     }
   }

--- a/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
+++ b/frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue
@@ -88,6 +88,7 @@
                                         :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
                                         :label="$t(`annotation.offensive.subquestion3.substatement${(idx+1)}`)"
                                         class="subquestions-item__checkbox"
+                                        hide-details
                                         @change="onLabelChange(substatement, `subquestion3`, idx)" />
 
                                     <textfield-modal
@@ -125,6 +126,7 @@
                                             :disabled="!hasFilledTopQuestions || substatement.isSubmitting"
                                             :label="$t(`annotation.offensive.subquestion4.substatement${(idx+1)}`)" 
                                             class="subquestions-item__checkbox"
+                                            hide-details
                                             @change="onLabelChange(substatement, `subquestion4`, idx)"
                                         />
 
@@ -490,63 +492,64 @@ export default Vue.extend({
       border: 2px solid red;
     }
   }
-}
 
-.widget {
-  font-size: 0.8rem;
+  .widget {
+    font-size: 0.8rem;
 
-  &__title {
-    font-size: 1rem;
-    font-weight: bold;
-    margin-bottom: 10px;
-  }
-
-  &__questions {
-    padding: none;
-  }
-}
-
-.questions-item {
-  opacity: 0.3;
-
-  &.--visible {
-    opacity: 1;
-  }
-
-  &__slider {
-    display: flex;
-
-    .v-slider__tick-label {
-      font-size: 0.8rem;
+    &__title {
+      font-size: 1rem;
+      font-weight: bold;
+      margin-bottom: 10px;
     }
 
-    .slider-text {
-      color: gray;
-      margin-top: 5px;
-
-      &.--start {
-        margin-right: 10px;
-      }
-
-      &.--end {
-        margin-left: 10px;
-      }
+    &__questions {
+      padding: none;
     }
   }
-}
 
-.subquestions {
-  list-style-type: none;
-  padding: 0;
+  .questions-item {
+    opacity: 0.3;
 
-  &__item {
-    .subquestions-item__checkbox {
-      .v-label {
+    &.--visible {
+      opacity: 1;
+    }
+
+    &__slider {
+      display: flex;
+
+      .v-slider__tick-label {
         font-size: 0.8rem;
       }
 
-      .v-input__slot {
-        margin: 0;
+      .slider-text {
+        color: gray;
+        margin-top: 5px;
+        font-size: 0.8rem;
+
+        &.--start {
+          margin-right: 10px;
+        }
+
+        &.--end {
+          margin-left: 10px;
+        }
+      }
+    }
+  }
+
+  .subquestions {
+    list-style-type: none;
+    padding: 0;
+
+    &__item {
+      .subquestions-item__checkbox {
+        .v-label {
+          font-size: 0.8rem;
+        }
+
+        .v-input__slot {
+          margin: 0;
+        }
       }
     }
   }

--- a/frontend/components/tasks/dynamicAnnotation/CheckboxInput.vue
+++ b/frontend/components/tasks/dynamicAnnotation/CheckboxInput.vue
@@ -2,7 +2,12 @@
   <div
     ref="checkboxInput"
     class="checkbox-input"
-    :class="{ '--preview': preview, '--readonly': readOnly }"
+    :class="{
+      '--preview': preview,
+      '--readonly': readOnly,
+      '--disabled': disabled,
+      '--transparent': transparent
+    }"
   >
     <div v-if="config.isMultipleAnswers" class="questions-item">
       <div class="questions-item__text">
@@ -25,7 +30,7 @@
               v-model="formData.checkedOptions"
               :required="required"
               :readonly="readOnly || preview"
-              :disabled="readOnly || preview || formData.isSubmitting"
+              :disabled="disabled || formData.isSubmitting"
               :rules="[
                 rules.requiredMultipleCheckboxes,
                 rules.minAnswerNumber,
@@ -49,7 +54,7 @@
         :required="required"
         :rules="[rules.requiredSingleCheckbox]"
         :readonly="readOnly || preview"
-        :disabled="readOnly || preview || formData.isSubmitting"
+        :disabled="disabled || formData.isSubmitting"
         :label="name + (required ? ' *' : '')"
         class="content-item__checkbox"
         @click="onCheckboxClick"
@@ -107,6 +112,14 @@ export default Vue.extend({
       default: () => []
     },
     readOnly: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+    transparent: {
       type: Boolean,
       default: false
     },
@@ -358,7 +371,11 @@ export default Vue.extend({
   }
 
   &.--readonly {
-    opacity: 0.8;
+    opacity: 0.85;
+  }
+
+  &.--transparent {
+    opacity: 0.3;
   }
 
   .--multiple {
@@ -366,30 +383,30 @@ export default Vue.extend({
       display: none;
     }
   }
-}
 
-.questions-item {
-  &__text {
-    margin-bottom: 10px;
+  .questions-item {
+    &__text {
+      margin-bottom: 10px;
+    }
+
+    .v-input--selection-controls {
+      margin-top: 0 !important;
+    }
   }
 
-  .v-input--selection-controls {
-    margin-top: 0 !important;
-  }
-}
+  .content {
+    list-style-type: none;
+    padding: 0;
 
-.content {
-  list-style-type: none;
-  padding: 0;
+    &__item {
+      .content-item__checkbox {
+        .v-label {
+          font-size: 1rem;
+        }
 
-  &__item {
-    .content-item__checkbox {
-      .v-label {
-        font-size: 1rem;
-      }
-
-      .v-input__slot {
-        margin: 0;
+        .v-input__slot {
+          margin: 0;
+        }
       }
     }
   }

--- a/frontend/components/tasks/dynamicAnnotation/SliderInput.vue
+++ b/frontend/components/tasks/dynamicAnnotation/SliderInput.vue
@@ -23,7 +23,7 @@
               "
               :track-color="!formData.isCheckboxChecked && formData.isClicked ? '' : 'grey'"
               ticks="always"
-              :disabled="!!formData.isCheckboxChecked"
+              :disabled="disabled || !!formData.isCheckboxChecked"
               :readonly="!!formData.isCheckboxChecked || preview || readOnly"
               :min="sliderMin"
               :max="sliderMax"
@@ -106,15 +106,19 @@ export default Vue.extend({
       type: Boolean,
       default: false
     },
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+    transparent: {
+      type: Boolean,
+      default: false
+    },
     required: {
       type: Boolean,
       default: false
     },
     preview: {
-      type: Boolean,
-      default: false
-    },
-    transparent: {
       type: Boolean,
       default: false
     },

--- a/frontend/components/tasks/dynamicAnnotation/SliderInput.vue
+++ b/frontend/components/tasks/dynamicAnnotation/SliderInput.vue
@@ -30,7 +30,7 @@
               :tick-labels="tickLabels"
               :step="sliderStep"
               @input="onSliderInput"
-              @click="onSliderClick"
+              @change="onSliderChange"
             />
 
             <span class="slider-text --end">
@@ -293,7 +293,7 @@ export default Vue.extend({
     onSliderInput() {
       this.formData.isClicked = true
     },
-    onSliderClick() {
+    onSliderChange() {
       if (!this.formData.isSubmitting) {
         this.formData.isSubmitting = true
         this.$emit('update:scale', { formDataKey: this.formDataKey, value: this.formData.value })

--- a/frontend/components/tasks/dynamicAnnotation/SliderInput.vue
+++ b/frontend/components/tasks/dynamicAnnotation/SliderInput.vue
@@ -114,6 +114,10 @@ export default Vue.extend({
       type: Boolean,
       default: false
     },
+    transparent: {
+      type: Boolean,
+      default: false
+    },
     playground: {
       type: Boolean,
       default: false
@@ -308,45 +312,46 @@ export default Vue.extend({
   &.--readonly {
     opacity: 0.85;
   }
-}
-.questions-item {
-  &__slider {
-    display: flex;
-    flex-wrap: wrap;
 
-    > * {
-      flex-basis: 100%;
-    }
-
-    .slider__slider {
+  .questions-item {
+    &__slider {
       display: flex;
-      padding-top: 10px;
+      flex-wrap: wrap;
 
-      > .slider-text {
-        max-width: 15%;
-        font-size: 0.75rem;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        word-break: break-word;
+      > * {
+        flex-basis: 100%;
+      }
+
+      .slider__slider {
+        display: flex;
+        padding-top: 10px;
+
+        > .slider-text {
+          max-width: 15%;
+          font-size: 0.75rem;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          word-break: break-word;
+        }
       }
     }
   }
-}
 
-.slider-text {
-  color: gray;
-  margin-top: 5px;
+  .slider-text {
+    color: gray;
+    margin-top: 5px;
 
-  &.--start {
-    margin-right: 10px;
+    &.--start {
+      margin-right: 10px;
+    }
+
+    &.--end {
+      margin-left: 10px;
+    }
   }
 
-  &.--end {
-    margin-left: 10px;
+  .v-slider__tick .v-slider__tick-label {
+    font-size: 0.75rem !important;
   }
-}
-
-.v-slider__tick .v-slider__tick-label {
-  font-size: 0.75rem !important;
 }
 </style>


### PR DESCRIPTION
Features added with this PR:
- Ability to set Humor and Offensive checkboxes question required status by humor and offensive sliders value. The question required state will be set as true when at least one humor/offensive sliders is checked and the value > 0 
- Fixed a styling bug: I forgot to put the styling for the component inside the parent `{}`, hence if we opened the DynamicAnnotation project after the AffectiveAnnotation project, the styling may conflict with each other. I apologize for the inconvenience

What's changed: 
- `frontend/components/tasks/affectiveAnnotation/humor/HumorInput.vue`: moved the styling inside `.humor-input {}`
- `frontend/components/tasks/affectiveAnnotation/offensive/OffensiveInput.vue`: moved the styling inside `.offensive-input {}`
- `frontend/components/tasks/dynamicAnnotation/CheckboxInput.vue`: moved the styling inside `.checkbox-input {}`, disabled & transparent rules, minor styling
- `frontend/components/tasks/dynamicAnnotation/SliderInput.vue`: moved the styling inside `.slider-input {}`, disabled r& transparent rules  
- `frontend/pages/projects/_id/dynamic-annotation/index.vue`: set the dim required + disabled + transparent props value based on their type and their value

Screenshots: 
![image](https://user-images.githubusercontent.com/12537724/230731786-745fddb6-45b0-45d7-b86e-7e81f768374c.png)
![image](https://user-images.githubusercontent.com/12537724/230731814-70954df3-8568-44ba-a154-f0dea770a9b7.png)
![image](https://user-images.githubusercontent.com/12537724/230731828-765f064f-6034-4f3d-bed9-e70a54a134a7.png)

