### PR TITLE
fix: 1943 - FE - Investigate and fix random redirect from annotation page to /projects page

### DIFF
--- a/frontend/components/layout/TheHeader.vue
+++ b/frontend/components/layout/TheHeader.vue
@@ -25,7 +25,7 @@
       v-if="isAuthenticated"
       text
       class="text-capitalize"
-      @click="$router.push(localePath('/projects'))"
+      @click.once="$router.push(localePath('/projects'))"
     >
       {{ $t('header.projects') }}
     </v-btn>
@@ -40,7 +40,7 @@
         <v-list-item
           v-for="(item, index) in items"
           :key="index"
-          @click="$router.push('/demo/' + item.link)"
+          @click.once="$router.push(localePath('/demo/' + item.link))"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>

--- a/frontend/components/layout/TheSideBar.vue
+++ b/frontend/components/layout/TheSideBar.vue
@@ -15,7 +15,7 @@
       <v-list-item
         v-for="(item, i) in filteredItems"
         :key="i"
-        @click="$router.push(localePath(`/projects/${$route.params.id}/${item.link}`))"
+        @click.once="$router.push(localePath(`/projects/${$route.params.id}/${item.link}`))"
       >
         <v-list-item-action>
           <v-icon>

--- a/frontend/components/project/ProjectList.vue
+++ b/frontend/components/project/ProjectList.vue
@@ -34,8 +34,8 @@
     <template #[`item.name`]="{ item }">
       <span
         v-if="enableProjectLink(item.id)"
-        @click.once="$router.push(localePath(`/projects/${item.id}`))"
         class="item-link"
+        @click.once="$router.push(localePath(`/projects/${item.id}`))"
       >
         <span>{{ item.name }}</span>
       </span>

--- a/frontend/components/project/ProjectList.vue
+++ b/frontend/components/project/ProjectList.vue
@@ -32,9 +32,13 @@
       />
     </template>
     <template #[`item.name`]="{ item }">
-      <nuxt-link v-if="enableProjectLink(item.id)" :to="localePath(`/projects/${item.id}`)">
+      <span
+        v-if="enableProjectLink(item.id)"
+        @click.once="$router.push(localePath(`/projects/${item.id}`))"
+        class="item-link"
+      >
         <span>{{ item.name }}</span>
-      </nuxt-link>
+      </span>
       <span v-else>{{ item.name }}</span>
     </template>
     <template #[`item.updatedAt`]="{ item }">
@@ -157,3 +161,10 @@ export default Vue.extend({
   }
 })
 </script>
+<style lang="scss" scoped>
+.item-link {
+  color: blue;
+  text-decoration: underline;
+  cursor: pointer;
+}
+</style>

--- a/frontend/domain/models/example/exampleRepository.ts
+++ b/frontend/domain/models/example/exampleRepository.ts
@@ -5,7 +5,7 @@ export type SearchOption = { [key: string]: string | (string | null)[] }
 export interface ExampleRepository {
   list(projectId: string, { limit, offset, q, isChecked }: SearchOption): Promise<ExampleItemList>
 
-  articleIds(projectId: string, limit: string): Promise<Array<string>>
+  fetchArticleIds(projectId: string, limit: string): Promise<Array<string>>
 
   create(projectId: string, item: ExampleItem): Promise<ExampleItem>
 

--- a/frontend/layouts/project.vue
+++ b/frontend/layouts/project.vue
@@ -32,7 +32,7 @@ export default {
     TheSideBar,
     TheHeader
   },
-  middleware: ['check-auth', 'auth', 'check-admin', 'check-questionnaire'],
+  middleware: ['check-admin', 'check-questionnaire'],
   data() {
     return {
       drawerLeft: null,

--- a/frontend/layouts/questionnaire.vue
+++ b/frontend/layouts/questionnaire.vue
@@ -15,45 +15,42 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import {
-  qCategories,
-  getQuestionnaireTypes,
-} from "~/utils/questionnaires"
+import { qCategories, getQuestionnaireTypes } from '~/utils/questionnaires'
 
-import TheHeader from "~/components/layout/TheHeader.vue"
+import TheHeader from '~/components/layout/TheHeader.vue'
 
 export default {
-    name: "Questionnaire",
-    components: {
-      TheHeader
-    },
-    middleware: ['check-auth', 'auth', 'check-questionnaire'],
+  name: 'Questionnaire',
+  components: {
+    TheHeader
+  },
+  middleware: ['check-questionnaire'],
   data() {
     return {
       qCategories,
-      qTypes: getQuestionnaireTypes(),
+      qTypes: getQuestionnaireTypes()
     }
   },
   computed: {
     ...mapGetters('user', ['getQuestionnaire']),
     toShowCategoryKey() {
-      const localeCodes = this.$i18n.locales.map((locale) => "/" + locale.code + "/")
+      const localeCodes = this.$i18n.locales.map((locale) => '/' + locale.code + '/')
       let indexToSplit = 2
       for (let i = 0; i < localeCodes.length; i++) {
         if (this.$route.path.includes(localeCodes[i])) {
           indexToSplit = 3
         }
       }
-      return this.$route.path.split("/")[indexToSplit]
+      return this.$route.path.split('/')[indexToSplit]
     },
     qCategoryId() {
-      return this.qCategories.find((qCategory)=> qCategory.key === this.toShowCategoryKey).id
+      return this.qCategories.find((qCategory) => qCategory.key === this.toShowCategoryKey).id
     },
     toShowId() {
-      return this.getQuestionnaire.toShow.find((qToShow)=> qToShow.startsWith(this.qCategoryId))
+      return this.getQuestionnaire.toShow.find((qToShow) => qToShow.startsWith(this.qCategoryId))
     },
     selectedQuestionnaire() {
-      return this.qTypes.find((qType)=> qType.id === this.toShowId)
+      return this.qTypes.find((qType) => qType.id === this.toShowId)
     }
   },
   created() {
@@ -61,11 +58,11 @@ export default {
   },
   methods: {
     validateQuestionnaire() {
-      const {toShow} = this.getQuestionnaire
-      if(toShow[0] !== this.toShowId) {
+      const { toShow } = this.getQuestionnaire
+      if (toShow[0] !== this.toShowId) {
         this.$router.push(this.localePath('/questionnaires'))
       }
-    },
+    }
   }
 }
 </script>

--- a/frontend/layouts/questionnaires.vue
+++ b/frontend/layouts/questionnaires.vue
@@ -21,6 +21,6 @@ export default {
   components: {
     TheHeader
   },
-  middleware: ['check-auth', 'auth', 'check-questionnaire']
+  middleware: ['check-questionnaire']
 }
 </script>

--- a/frontend/layouts/workspace.vue
+++ b/frontend/layouts/workspace.vue
@@ -26,7 +26,7 @@ export default {
     TheSideBar,
     TheHeader
   },
-  middleware: ['check-auth', 'auth', 'set-project', 'check-questionnaire'],
+  middleware: ['set-project', 'check-questionnaire'],
 
   data() {
     return {

--- a/frontend/middleware/auth.js
+++ b/frontend/middleware/auth.js
@@ -1,5 +1,7 @@
-export default function ({ store, redirect }) {
-  if (!store.getters['auth/isAuthenticated']) {
+export default function ({ route, store, redirect }) {
+  const outerPages = ["/", "/auth"]
+  const isDemoPage = route.path.startsWith("/demo")
+  if (!store.getters['auth/isAuthenticated'] && !outerPages.includes(route.path) && !isDemoPage) {
     redirect('/auth')
   }
 }

--- a/frontend/middleware/check-admin.js
+++ b/frontend/middleware/check-admin.js
@@ -10,9 +10,10 @@ export default _.debounce(async function ({ app, store, route, redirect }) {
     redirect('/projects')
   }
   
-  const isProjectAdmin = await app.$services.member.isProjectAdmin(route.params.id)
-  const projectRoot = app.localePath('/projects/' + route.params.id)
+  let isProjectAdmin = await app.$services.member.isProjectAdmin(route.params.id)
+  let projectRoot = app.localePath('/projects/' + route.params.id)
   const path = route.fullPath.replace(/\/$/g, '')
+  
   if(route.params.id) {
     isProjectAdmin = await app.$services.member.isProjectAdmin(route.params.id)
     projectRoot = app.localePath('/projects/' + route.params.id)

--- a/frontend/middleware/check-admin.js
+++ b/frontend/middleware/check-admin.js
@@ -13,7 +13,11 @@ export default _.debounce(async function ({ app, store, route, redirect }) {
   const isProjectAdmin = await app.$services.member.isProjectAdmin(route.params.id)
   const projectRoot = app.localePath('/projects/' + route.params.id)
   const path = route.fullPath.replace(/\/$/g, '')
-
+  if(route.params.id) {
+    isProjectAdmin = await app.$services.member.isProjectAdmin(route.params.id)
+    projectRoot = app.localePath('/projects/' + route.params.id)
+  }
+  
   if (isProjectAdmin || path === projectRoot || path.startsWith(projectRoot + '/dataset')) {
     return
   }

--- a/frontend/middleware/check-auth.js
+++ b/frontend/middleware/check-auth.js
@@ -1,5 +1,9 @@
-export default async function ({ store }) {
-  if (!store.getters['auth/isAuthenticated'] || !store.getters['auth/getUsername']) {
+export default async function ({ route, store }) {
+  const outerPages = ["/", "/auth"]
+  const isDemoPage = route.path.startsWith("/demo")
+  const isOuterPage = outerPages.includes(route.path) || isDemoPage 
+  const hasIncompleteData = !store.getters['auth/isAuthenticated'] || !store.getters['auth/getUsername']
+  if (!isOuterPage && hasIncompleteData) {
     await store.dispatch('auth/initAuth')
     store.dispatch('user/init', store.getters['auth/getUserId'])
   }

--- a/frontend/middleware/check-project.js
+++ b/frontend/middleware/check-project.js
@@ -2,7 +2,7 @@ export default async function ({ app, store, route, redirect }) {
     const isStaff = store.getters['auth/isStaff']
     const allowedProjectId = store.getters['user/getCurrentlyAllowedProjectId'] || -1
     const openedProjectId = route.params.id
-    if(openedProjectId && !isStaff) {
+    if(openedProjectId && String(openedProjectId) !== "undefined" && !isStaff) {
         const progress = await app.$services.metrics.fetchMyProgress(openedProjectId)
         const canAccess = progress.remaining > 0 && progress.total > 0 && allowedProjectId.toString() === openedProjectId
         if (!canAccess) {

--- a/frontend/middleware/check-project.js
+++ b/frontend/middleware/check-project.js
@@ -7,6 +7,6 @@ export default async function ({ app, store, route, redirect }) {
         const canAccess = progress.remaining > 0 && progress.total > 0 && allowedProjectId.toString() === openedProjectId
         if (!canAccess) {
             return redirect('/projects')
-        } 
+        }
     }
 }

--- a/frontend/middleware/check-questionnaire.js
+++ b/frontend/middleware/check-questionnaire.js
@@ -14,7 +14,6 @@ export default function ({ store, route, redirect, app }) {
         const locale = app.i18n.locale ?? 'pl'
         
         if(!isStaff && toShow.length && !isOnQuestionnairePage) {
-            console.log("test")
             return redirect("/"+ locale + "/questionnaires")
         } 
         else if(!isStaff && toShow.length && isOnQuestionnairePage) {

--- a/frontend/middleware/check-questionnaire.js
+++ b/frontend/middleware/check-questionnaire.js
@@ -14,11 +14,12 @@ export default function ({ store, route, redirect, app }) {
         const locale = app.i18n.locale ?? 'pl'
         
         if(!isStaff && toShow.length && !isOnQuestionnairePage) {
+            console.log("test")
             return redirect("/"+ locale + "/questionnaires")
         } 
         else if(!isStaff && toShow.length && isOnQuestionnairePage) {
             if(isWorkingNow && (isOnMainQuestionnairePage || !route.path.includes(key))) { 
-                redirect(`/${locale}/questionnaires/${key}`)
+                return redirect(`/${locale}/questionnaires/${key}`)
             }
         }
     } else if(hasValidToShow && !toShow.length && isOnQuestionnairePage)  {

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -173,6 +173,6 @@ export default {
     }
   },
   router: {
-    middleware: ['check-project']
+    middleware: ['check-auth', 'auth', 'check-project']
   }
 }

--- a/frontend/pages/projects/_id/affective-annotation/index.vue
+++ b/frontend/pages/projects/_id/affective-annotation/index.vue
@@ -309,7 +309,8 @@ export default {
   layout: 'workspace',
 
   validate({ params, query }) {
-    return /^\d+$/.test(params.id) && /^\d+$/.test(query.page)
+    const hasValidQueryAndParams = /^\d+$/.test(params.id) && /^\d+$/.test(query.page)
+    return hasValidQueryAndParams
   },
 
   data() {
@@ -336,7 +337,6 @@ export default {
       selectedLabelIndex: null,
       progress: {},
       relationMode: false,
-      isProjectAdmin: false,
       articleTotal: 1,
       articleIndex: 1,
       isScaleImported: true,
@@ -387,7 +387,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters('auth', ['isAuthenticated', 'getUsername', 'getUserId']),
+    ...mapGetters('auth', ['isAuthenticated', 'isStaff', 'getUsername', 'getUserId']),
     ...mapGetters('config', ['isRTL']),
     ...mapGetters('user', ['getAnnotation']),
     shortKeysSpans() {
@@ -413,21 +413,21 @@ export default {
       return !!this.project?.isSingleAnnView
     },
     showFilterButton() {
-      return this.isAffectiveAnnotation ? this.isProjectAdmin : true
+      return this.isAffectiveAnnotation ? this.isStaff : true
     },
     canEdit() {
-      return this.isAffectiveAnnotation && this.doc.isConfirmed ? this.isProjectAdmin : true
+      return this.isAffectiveAnnotation && this.doc.isConfirmed ? this.isStaff : true
     },
     canNavigateBackward() {
-      const canNavigateBackward = this.isProjectAdmin || !this.hasCheckedPreviousDoc
+      const canNavigateBackward = this.isStaff || !this.hasCheckedPreviousDoc
       return this.isAffectiveAnnotation ? canNavigateBackward : true
     },
     canNavigateForward() {
-      const canNavigateForward = this.isProjectAdmin ? true : this.doc.isConfirmed
+      const canNavigateForward = this.isStaff ? true : this.doc.isConfirmed
       return this.isAffectiveAnnotation ? canNavigateForward : true
     },
     canSkipForward() {
-      return this.isAffectiveAnnotation ? this.isProjectAdmin : true
+      return this.isAffectiveAnnotation ? this.isStaff : true
     },
     showAutoLabeling() {
       return !this.isAffectiveAnnotation
@@ -819,8 +819,8 @@ export default {
       } else if (this.project.isEmotionsMode) {
         this.hasValidEntries.isEmotionsMode = this.isAllAffectiveEmotionsAdded()
       }
-      this.hasClickedConfirmButton = this.canConfirm ? false : !this.isProjectAdmin
-      if (this.canConfirm || this.isProjectAdmin) {
+      this.hasClickedConfirmButton = this.canConfirm ? false : !this.isStaff
+      if (this.canConfirm || this.isStaff) {
         await this.$services.example.confirm(this.projectId, this.doc.id)
         await this.$fetch()
         this.updateProgress()

--- a/frontend/pages/projects/create.vue
+++ b/frontend/pages/projects/create.vue
@@ -16,8 +16,6 @@ export default Vue.extend({
 
   layout: 'projects',
 
-  middleware: ['check-auth', 'auth'],
-
   data() {
     return {
       dimensions: [] as DimensionDTO[],

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -68,6 +68,8 @@ export default Vue.extend({
   },
   layout: 'projects',
 
+  middleware: ['check-auth', 'auth'],
+
   data() {
     return {
       dialogDelete: false,

--- a/frontend/pages/projects/index.vue
+++ b/frontend/pages/projects/index.vue
@@ -68,8 +68,6 @@ export default Vue.extend({
   },
   layout: 'projects',
 
-  middleware: ['check-auth', 'auth'],
-
   data() {
     return {
       dialogDelete: false,

--- a/frontend/pages/questionnaires/index.vue
+++ b/frontend/pages/questionnaires/index.vue
@@ -17,7 +17,6 @@ export default {
     GreetingCard
   },
   layout: 'questionnaires',
-  middleware: ['check-auth', 'auth'],
   data() {
     return {
       qCategories

--- a/frontend/repositories/example/apiDocumentRepository.ts
+++ b/frontend/repositories/example/apiDocumentRepository.ts
@@ -10,15 +10,23 @@ export class APIExampleRepository implements ExampleRepository {
     projectId: string,
     { limit = '10', offset = '0', q = '', isChecked = '' }: SearchOption
   ): Promise<ExampleItemList> {
-    const url = `/projects/${projectId}/examples?limit=${limit}&offset=${offset}&q=${q}&confirmed=${isChecked}`
-    const response = await this.request.get(url)
-    return plainToInstance(ExampleItemList, response.data)
+    let result = Promise.resolve({count: 0, next: null, prev: null, items: []})
+    if (String(projectId) !== "undefined") {
+      const url = `/projects/${projectId}/examples?limit=${limit}&offset=${offset}&q=${q}&confirmed=${isChecked}`
+      const response = await this.request.get(url)
+      result =  response.data
+    }
+    return result
   }
 
-  async articleIds(projectId: string, limit = '999999'): Promise<Array<string>> {
-    const url = `/projects/${projectId}/article_ids?limit=${limit}&offset=0`
-    const response = await this.request.get(url)
-    return response.data.results.map((i: any) => i.article_id)
+  async fetchArticleIds(projectId: string, limit = '999999'): Promise<Array<string>> {
+    let results = Promise.resolve([])
+    if (String(projectId) !== "undefined") {
+      const url = `/projects/${projectId}/article_ids?limit=${limit}&offset=0`
+      const response = await this.request.get(url)
+      results = response.data.results.map((i: any) => i.article_id)
+    }
+    return results
   }
 
   async create(projectId: string, item: ExampleItem): Promise<ExampleItem> {
@@ -50,9 +58,13 @@ export class APIExampleRepository implements ExampleRepository {
   }
 
   async listStates(projectId: string, exampleId: number): Promise<ExampleStateItemList> {
-    const url = `/projects/${projectId}/examples/${exampleId}/states`
-    const response = await this.request.get(url)
-    return plainToInstance(ExampleStateItemList, response.data)
+    let result = Promise.resolve({count: 0, next: null, prev: null, items: []})
+    if (String(projectId) !== "undefined" && String(exampleId) !== "undefined") {
+      const url = `/projects/${projectId}/examples/${exampleId}/states`
+      const response = await this.request.get(url)
+      result = response.data
+    }
+    return result
   }
 
   async confirm(projectId: string, exampleId: number): Promise<void> {

--- a/frontend/repositories/member/apiMemberRepository.ts
+++ b/frontend/repositories/member/apiMemberRepository.ts
@@ -31,7 +31,7 @@ export class APIMemberRepository implements MemberRepository {
 
   async fetchMyRole(projectId: string): Promise<MemberItem> {
     const url = `/projects/${projectId}/my-role`
-    const response = await this.request.get(url)
+    const response = projectId ? await this.request.get(url) : { data: {}}
     return plainToInstance(MemberItem, response.data)
   }
 }

--- a/frontend/repositories/metrics/apiMetricsRepository.ts
+++ b/frontend/repositories/metrics/apiMetricsRepository.ts
@@ -6,33 +6,60 @@ export class APIMetricsRepository implements MetricsRepository {
   constructor(private readonly request = ApiService) {}
 
   async fetchCategoryDistribution(projectId: string): Promise<Distribution> {
-    const url = `/projects/${projectId}/metrics/category-distribution`
-    const response = await this.request.get(url)
-    return response.data
+    let result = Promise.resolve({ user: {} })
+    if (String(projectId) !== "undefined") {
+      const url = `/projects/${projectId}/metrics/category-distribution`
+      const response = await this.request.get(url)
+      result = response.data
+    }
+    return result
   }
 
   async fetchSpanDistribution(projectId: string): Promise<Distribution> {
-    const url = `/projects/${projectId}/metrics/span-distribution`
-    const response = await this.request.get(url)
-    return response.data
+    let result = Promise.resolve({ user: {} })
+    if (String(projectId) !== "undefined") {
+      const url = `/projects/${projectId}/metrics/span-distribution`
+      const response = await this.request.get(url)
+      result = response.data
+    }
+    return result
   }
 
   async fetchRelationDistribution(projectId: string): Promise<Distribution> {
-    const url = `/projects/${projectId}/metrics/relation-distribution`
-    const response = await this.request.get(url)
-    return response.data
+    let result = Promise.resolve({ user: {} })
+    if (String(projectId) !== "undefined") {
+      const url = `/projects/${projectId}/metrics/relation-distribution`
+      const response = await this.request.get(url)
+      result = response.data
+    }
+    return result
   }
 
   async fetchMemberProgress(projectId: string): Promise<Progress> {
-    const url = `/projects/${projectId}/metrics/member-progress`
-    const response = await this.request.get(url)
-    return response.data
+    let result = Promise.resolve({
+      total: 0,
+      progress: []
+    })
+    if (String(projectId) !== "undefined") {
+      const url = `/projects/${projectId}/metrics/member-progress`
+      const response = await this.request.get(url)
+      result = response.data
+    }
+    return result
   }
 
   async fetchMyProgress(projectId: string): Promise<MyProgress> {
-    const url = `/projects/${projectId}/metrics/progress`
-    const response = await this.request.get(url)
-    return response.data
+    let result = Promise.resolve({
+      total: 0,
+      complete: 0,
+      remaining: 0,
+    })
+    if (String(projectId) !== "undefined") {
+      const url = `/projects/${projectId}/metrics/progress`
+      const response = await this.request.get(url)
+      result = response.data
+    }
+    return result
   }
 
   async fetchMyProgresses() :Promise<MyProgressList> {

--- a/frontend/repositories/project/apiProjectRepository.ts
+++ b/frontend/repositories/project/apiProjectRepository.ts
@@ -14,7 +14,7 @@ export class APIProjectRepository implements ProjectRepository {
 
   async findById(id: string): Promise<ProjectReadItem> {
     const url = `/projects/${id}`
-    const response = await this.request.get(url)
+    const response = id ? await this.request.get(url) : { data: {}}
     return plainToInstance(ProjectReadItem, response.data)
   }
 

--- a/frontend/repositories/tasks/sequenceLabeling/apiRelationRepository.ts
+++ b/frontend/repositories/tasks/sequenceLabeling/apiRelationRepository.ts
@@ -6,9 +6,13 @@ export class ApiRelationRepository implements RelationRepository {
   constructor(private readonly request = ApiService) {}
 
   async list(projectId: string, exampleId: number): Promise<RelationItem[]> {
-    const url = `/projects/${projectId}/examples/${exampleId}/relations`
-    const response = await this.request.get(url)
-    return response.data.map((relation: any) => RelationItem.valueOf(relation))
+    let result = Promise.resolve([])
+    if (String(projectId) !== "undefined") {
+      const url = `/projects/${projectId}/examples/${exampleId}/relations`
+      const response = await this.request.get(url)
+      result =  response.data.map((relation: any) => RelationItem.valueOf(relation))
+    }
+    return result
   }
 
   async create(projectId: string, exampleId: number, item: RelationItem): Promise<RelationItem> {

--- a/frontend/services/application/example/exampleApplicationService.ts
+++ b/frontend/services/application/example/exampleApplicationService.ts
@@ -48,7 +48,7 @@ export class ExampleApplicationService {
 
   public async fetchArticleIds(projectId: string, count: string): Promise<Array<string>> {
     try {
-      const item = await this.repository.articleIds(projectId, count)
+      const item = await this.repository.fetchArticleIds(projectId, count)
       return item
     } catch (e: any) {
       throw new Error(e.response.data.detail)


### PR DESCRIPTION
This PR was made to replace PR https://github.com/CLARIN-PL/doccano/pull/74. That PR was rebased to the refactor PR and having it merged means that the refactor PR will be merged as well, so I cherry-picked the commits to make this PR and closed earlier PR. The changes are the same. 

--------------------------------------------------------------- COPIED FROM PR #74 -----------------------------------------------------------------------

Issues fixed with this PR: 
Sometimes the page will redirect user randomly to the projects page. Our assumption for now is because the page is loaded before the apis because of poor internet connection.
https://redmine.e-science.pl/clarin/issues/1943 

Analysis: 
After doing some analysis, I decided that the problem indeed has something to do with the poor internet connection, but not with the `/index.vue` page, but rather the middleware. The `check-project` calls the `isStaff` value, but this value was being loaded after the `check-project` middleware loaded in first load, because the `check-project` middleware was loaded in the `nuxt.config.js` (prioritized) and the `check-auth` was loaded before loading each page (lower priority). Because of this, I moved the `check-auth` and `auth` to `config` and handled the code accordingly. 

Tested with throttled internet connection in Linux with this command: 
`sudo tc qdisc add dev lo root netem delay 100ms`
to remove: `sudo tc qdisc del dev lo root `

What's changed: 
- `frontend/layouts/*.vue`: removed `check-auth`, `auth`
- `frontend/middleware/auth.js`: added additional check to exlude outer pages from authorization 
- `frontend/middleware/check-auth.js`: added additional check to exlude outer pages from authorization 
- `frontend/nuxt.config.js`: added `check-auth`, `auth` middlewares
- `frontend/pages/projects/_id/affective-annotation/index.vue`: changed `isProjectAdmin` to `isStaff` in case the isProjectAdmin value wasnt properly loaded 
- `frontend/repositories/member/*.ts`: minor fix, handle empty/undefined id 
