### PR TITLE
Dynamic Annotation project - Remove unused log - be

### DIFF
--- a/backend/labels/views.py
+++ b/backend/labels/views.py
@@ -121,7 +121,6 @@ class ScaleListAPI(BaseListAPI):
     def create(self, request, *args, **kwargs):
         if self.project.is_affective_annotation_project:
             queryset = Scale.objects.filter(example=self.kwargs["example_id"], label=request.data['label'])
-            print(queryset)
             if not self.project.collaborative_annotation:
                 queryset = queryset.filter(user=self.request.user)
             queryset.delete()


### PR DESCRIPTION
Hello, I have removed the `print()` in query set to keep the be running silently.

File changed:
`backend/labels/views.py`: removed `print()`