### PR TITLE
hotfix: Expose errors

### DIFF
--- a/frontend/components/layout/TheHeader.vue
+++ b/frontend/components/layout/TheHeader.vue
@@ -25,7 +25,7 @@
       v-if="isAuthenticated"
       text
       class="text-capitalize"
-      @click.once="$router.push(localePath('/projects'))"
+      @click="$router.push(localePath('/projects'))"
     >
       {{ $t('header.projects') }}
     </v-btn>
@@ -40,7 +40,7 @@
         <v-list-item
           v-for="(item, index) in items"
           :key="index"
-          @click.once="$router.push(localePath('/demo/' + item.link))"
+          @click="$router.push(localePath('/demo/' + item.link))"
         >
           <v-list-item-title>{{ item.title }}</v-list-item-title>
         </v-list-item>

--- a/frontend/components/layout/TheSideBar.vue
+++ b/frontend/components/layout/TheSideBar.vue
@@ -15,7 +15,7 @@
       <v-list-item
         v-for="(item, i) in filteredItems"
         :key="i"
-        @click.once="$router.push(localePath(`/projects/${$route.params.id}/${item.link}`))"
+        @click="$router.push(localePath(`/projects/${$route.params.id}/${item.link}`))"
       >
         <v-list-item-action>
           <v-icon>
@@ -77,11 +77,11 @@ export default {
       return !hideAnnotationButtonProjectTypes.includes(this.project.projectType)
     },
     filteredItems() {
-      const items = [
+      return [
         {
           icon: mdiHome,
           text: this.$t('projectHome.home'),
-          link: '',
+          link: '/',
           isVisible: true
         },
         {
@@ -132,8 +132,7 @@ export default {
           link: 'settings',
           isVisible: this.isProjectAdmin
         }
-      ]
-      return items.filter((item) => item.isVisible)
+      ].filter((item) => item.isVisible)
     }
   },
 

--- a/frontend/components/layout/TheSideBar.vue
+++ b/frontend/components/layout/TheSideBar.vue
@@ -81,7 +81,7 @@ export default {
         {
           icon: mdiHome,
           text: this.$t('projectHome.home'),
-          link: '/',
+          link: '',
           isVisible: true
         },
         {

--- a/frontend/components/project/ProjectList.vue
+++ b/frontend/components/project/ProjectList.vue
@@ -35,7 +35,7 @@
       <span
         v-if="enableProjectLink(item.id)"
         class="item-link"
-        @click.once="$router.push(localePath(`/projects/${item.id}`))"
+        @click="$router.push(localePath(`/projects/${item.id}`))"
       >
         <span>{{ item.name }}</span>
       </span>

--- a/frontend/domain/models/example/example.ts
+++ b/frontend/domain/models/example/example.ts
@@ -87,7 +87,6 @@ export class ExampleItemList {
   next: string | null
   prev: string | null
 
-  @Type(() => ExampleItem)
   @Expose({ name: 'results' })
-  items: ExampleItem[]
+  results: ExampleItem[]
 }

--- a/frontend/domain/models/example/example.ts
+++ b/frontend/domain/models/example/example.ts
@@ -87,6 +87,5 @@ export class ExampleItemList {
   next: string | null
   prev: string | null
 
-  @Expose({ name: 'results' })
   results: ExampleItem[]
 }

--- a/frontend/layouts/project.vue
+++ b/frontend/layouts/project.vue
@@ -7,7 +7,7 @@
     </the-header>
 
     <v-navigation-drawer v-model="drawerLeft" app clipped color="">
-      <the-side-bar :link="getLink" :is-project-admin="isProjectAdmin" :project="currentProject" />
+      <the-side-bar :link="getLink" :is-project-admin="isStaff" :project="currentProject" />
     </v-navigation-drawer>
 
     <v-main>
@@ -35,17 +35,13 @@ export default {
   middleware: ['check-admin', 'check-questionnaire'],
   data() {
     return {
-      drawerLeft: null,
-      isProjectAdmin: false
+      drawerLeft: null
     }
   },
 
   computed: {
+    ...mapGetters('auth', ['isStaff']),
     ...mapGetters('projects', ['getLink', 'currentProject'])
-  },
-
-  async created() {
-    this.isProjectAdmin = await this.$services.member.isProjectAdmin(this.$route.params.id)
   }
 }
 </script>

--- a/frontend/middleware/check-admin.js
+++ b/frontend/middleware/check-admin.js
@@ -1,6 +1,4 @@
-import _ from 'lodash'
-
-export default _.debounce(async function ({ app, store, route, redirect }) {
+export default async function ({ app, store, route, redirect }) {
   try {
     await store.dispatch('projects/setCurrentProject', route.params.id)
     await store.dispatch('projects/setCurrentDimensions', route.params.id)
@@ -23,5 +21,6 @@ export default _.debounce(async function ({ app, store, route, redirect }) {
     return
   }
 
+
   return redirect(projectRoot)
-}, 1000)
+}

--- a/frontend/repositories/example/apiDocumentRepository.ts
+++ b/frontend/repositories/example/apiDocumentRepository.ts
@@ -15,7 +15,9 @@ export class APIExampleRepository implements ExampleRepository {
       const url = `/projects/${projectId}/examples?limit=${limit}&offset=${offset}&q=${q}&confirmed=${isChecked}`
       const response = await this.request.get(url)
       result =  response.data
-    }
+    } 
+    // @ts-ignore 
+    // hotfix: Somehow the TypeScript will not expose the `results` to `items` but still reads them as `items`
     return result
   }
 

--- a/frontend/repositories/example/apiDocumentRepository.ts
+++ b/frontend/repositories/example/apiDocumentRepository.ts
@@ -10,14 +10,12 @@ export class APIExampleRepository implements ExampleRepository {
     projectId: string,
     { limit = '10', offset = '0', q = '', isChecked = '' }: SearchOption
   ): Promise<ExampleItemList> {
-    let result = Promise.resolve({count: 0, next: null, prev: null, items: []})
+    let result = Promise.resolve({count: 0, next: null, prev: null, results: []})
     if (String(projectId) !== "undefined") {
       const url = `/projects/${projectId}/examples?limit=${limit}&offset=${offset}&q=${q}&confirmed=${isChecked}`
       const response = await this.request.get(url)
       result =  response.data
     } 
-    // @ts-ignore 
-    // hotfix: Somehow the TypeScript will not expose the `results` to `items` but still reads them as `items`
     return result
   }
 

--- a/frontend/services/application/example/exampleApplicationService.ts
+++ b/frontend/services/application/example/exampleApplicationService.ts
@@ -11,7 +11,8 @@ export class ExampleApplicationService {
       const item = await this.repository.list(projectId, options)
       return new ExampleListDTO(item)
     } catch (e: any) {
-      throw new Error(e.response.data.detail)
+      console.error(e)
+      throw new Error(e.response)
     }
   }
 

--- a/frontend/services/application/example/exampleApplicationService.ts
+++ b/frontend/services/application/example/exampleApplicationService.ts
@@ -11,8 +11,7 @@ export class ExampleApplicationService {
       const item = await this.repository.list(projectId, options)
       return new ExampleListDTO(item)
     } catch (e: any) {
-      console.error(e)
-      throw new Error(e.response)
+      throw new Error(e.response.data.detail)
     }
   }
 
@@ -24,7 +23,7 @@ export class ExampleApplicationService {
   ): Promise<ExampleListDTO> {
     const offset = (parseInt(page, 10) - 1).toString()
     const options: SearchOption = {
-      limit: '1',
+    limit: '1',
       offset,
       q,
       isChecked

--- a/frontend/services/application/example/exampleData.ts
+++ b/frontend/services/application/example/exampleData.ts
@@ -74,8 +74,6 @@ export class ExampleStateListDTO {
   count: number
   next: string | null
   prev: string | null
-
-  @Expose({ name: 'results' })
   items: ExampleStateDTO[] 
 
   constructor(item: ExampleStateItemList) {

--- a/frontend/services/application/example/exampleData.ts
+++ b/frontend/services/application/example/exampleData.ts
@@ -33,7 +33,7 @@ export class ExampleDTO {
   isConfirmed: boolean
   articleId: string 
   type: string 
-  order: number
+  order: number | null 
   itemId: string 
 
   constructor(item: ExampleItem) {
@@ -74,13 +74,15 @@ export class ExampleStateListDTO {
   count: number
   next: string | null
   prev: string | null
-  items: ExampleStateDTO[]
+
+  @Expose({ name: 'results' })
+  items: ExampleStateDTO[] 
 
   constructor(item: ExampleStateItemList) {
     this.count = item.count
     this.next = item.next
     this.prev = item.prev
-    this.items = item.items.map((_) => new ExampleStateDTO(_))
+    this.items = item.items.map((_ : any ) => new ExampleStateDTO(_))
   }
 }
 
@@ -95,7 +97,7 @@ export class ExampleListDTO {
     this.count = item.count
     this.next = item.next
     this.prev = item.prev
-    this.items = item.items.map((_) => new ExampleDTO(_))
+    this.items = item.results.map((_: any) => new ExampleDTO(_))
   }
 }
 


### PR DESCRIPTION
Features fixed with this hotfix: 
- Somehow out of nowhere the `dataset` page doesn't work as previously. After checking, it was found that the Typescript somehow doesn't want to `Expose` the `results` data from the api to `items`, even though no changes were done. This hotfix removed the `Expose` and directly uses the `results` instead 
- The links on the `sidebar` didnt work well, it can only be clicked once and some of the links got wrongly filtered even though it received the right value from the api. After checking, it was found that the `delay` in the `check-admin` page caused it, which causes the project api to be delayed. Because of that, the `canDefineLabel` and `canDefineRelation` value returns as `undefined`, and the links get filtered. 

What's changed: 
- `frontend/components/layout/TheSideBar.vue`: removed the `once` handler
- `frontend/domain/models/example/example.ts`: removed the `Expose` handler
- `frontend/layouts/project.vue`: loaded the `isProjectAdmin` value from `isStaff` getters value instead to save loading time
- `frontend/middleware/check-admin.js`: removed debounce.
- `frontend/repositories/example/apiDocumentRepository.ts`: workaround to ignore ts errors because ts somehow still thinks that  the `ExampleItem` class value has `items` even though it was already set to `results`. 
- `frontend/services/application/example/exampleData.ts`: minor handling