### PR TITLE
Fix: Custom project type - project list API response in order

### DIFF
--- a/backend/projects/views/project.py
+++ b/backend/projects/views/project.py
@@ -24,7 +24,7 @@ class ProjectList(generics.ListCreateAPIView):
         return super().get_permissions()
 
     def get_queryset(self):
-        return Project.objects.filter(role_mappings__user=self.request.user)
+        return Project.objects.filter(role_mappings__user=self.request.user).order_by("created_at")
 
     def perform_create(self, serializer):
         project = serializer.save(created_by=self.request.user)


### PR DESCRIPTION
Hello, this PR aims to fix the bug resulted from the project list API. Originally, the responses from this API were not in order which mess up the project list for user when using the `limit` and `offset`. For example, for an current user, she has been assigned totally 15 projects, so the 1st page has 10 and 2nd page has 5 projects. As below, we can see that projects `ITER7` and `ITER8` have been appeared twice in both pages which is the results from the unordered results from API. And as a result, 2 other projects have been ommitted from the list in 2nd page.

![image](https://github.com/CLARIN-PL/doccano/assets/17596118/5bf3c1d7-0bc7-4af8-9589-87ff37e71485)
![image](https://github.com/CLARIN-PL/doccano/assets/17596118/89cc6cff-e181-4ca0-a196-37c5e829d93f)


To fix this I have added the `.order_by("created_at")` in the project list API's response.