### PR TITLE
Fix: Add questionaire IDs, clean the deletion

### DIFF
--- a/frontend/components/auth/FormLogin.vue
+++ b/frontend/components/auth/FormLogin.vue
@@ -237,7 +237,7 @@ export default Vue.extend({
 
         this.checkLoginDataValidity(lastLoginTime)
         this.setLoginData(loginTime)
-        this.filterDailyQuestionnaireEveryday(currentDiffDay)
+        this.setFilledQuestionnaire(currentDiffDay)
       } catch (error) {
         console.error(error)
       }
@@ -266,7 +266,7 @@ export default Vue.extend({
         this.setLogin({ isFirstLogin: false, lastLoginTime: loginTime })
       }
     },
-    filterDailyQuestionnaireEveryday(currentDiffDay: number) {
+    setFilledQuestionnaire(currentDiffDay: number) {
       if (currentDiffDay > 0) {
         const { filled } = this.getQuestionnaire
         const dailyQuestionnaireId = '4'
@@ -303,20 +303,23 @@ export default Vue.extend({
               if (this.isLoaded) {
                 await this.setUserData()
                 this.$nextTick(async () => {
-                  const questionnaireStates = await this.$services.questionnaire.listFinishedQuestionnaires({
-                    questionnaireTypeId: 1,
-                    limit: 1
-                  })
+                  const questionnaireStates =
+                    await this.$services.questionnaire.listFinishedQuestionnaires({
+                      questionnaireTypeId: 1,
+                      limit: 1
+                    })
                   let firstQuestionnaireEverDate = null
                   if (questionnaireStates && questionnaireStates.items.length > 0) {
                     const firstQuestionnaireEver = questionnaireStates.items[0].finishedAt
-                    firstQuestionnaireEverDate = moment(String(firstQuestionnaireEver)).format('DD-MM-YYYY')
+                    firstQuestionnaireEverDate = moment(String(firstQuestionnaireEver)).format(
+                      'DD-MM-YYYY'
+                    )
                   }
                   await this.initQuestionnaire(firstQuestionnaireEverDate)
                 })
                 this.$router.push(this.localePath('/projects'))
               }
-            }, 100)
+            }, 200)
           })
         }, 100)
       } catch {

--- a/frontend/components/questionnaires/form/SliderInput.vue
+++ b/frontend/components/questionnaires/form/SliderInput.vue
@@ -4,8 +4,8 @@
       {{ question }}
     </span>
     <span v-if="required && question" class="red--text">*</span>
-    <v-row align="start" justify="center">
-      <v-col cols="12" align="start">
+    <v-row align="center" justify="center">
+      <v-col cols="12">
         <v-slider
           v-model="sliderValue"
           class="slider"

--- a/frontend/pages/questionnaires/codziennie_w_trakcie/js/questionnaires.js
+++ b/frontend/pages/questionnaires/codziennie_w_trakcie/js/questionnaires.js
@@ -6,6 +6,7 @@ export const qTypes = [
             {
                 name: "Sen (rano)",
                 language: "pl",
+                id: 13,
                 typeId: "4.1",
                 segments: [
                     {
@@ -63,6 +64,7 @@ export const qTypes = [
             {
                 name: "Stres (rano)",
                 language: "pl",
+                id: 14,
                 typeId: "4.1",
                 segments: [
                     {
@@ -119,6 +121,7 @@ export const qTypes = [
             {
                 name: "Stres (wieczorem)",
                 language: "pl",
+                id: 15,
                 typeId: "4.2",
                 segments: [
                     {
@@ -169,6 +172,7 @@ export const qTypes = [
             {
                 name: "Zdrowie (wieczorem)",
                 language: "pl",
+                id: 16,
                 typeId: "4.2",
                 segments: [
                     {
@@ -217,6 +221,7 @@ export const qTypes = [
             {
                 name: "Emocje (w przerwie)",
                 language: "pl",
+                id: 17,
                 typeId: "4.3",
                 segments: [
                     {

--- a/frontend/pages/questionnaires/na_koniec/js/questionnaires.js
+++ b/frontend/pages/questionnaires/na_koniec/js/questionnaires.js
@@ -7,6 +7,7 @@ export const qTypes = [
                 name: "Ankieta na koniec badania",
                 language: "pl",
                 typeId: "5.1",
+                id: 18,
                 segments: [
                     {
                         questions: [

--- a/frontend/pages/questionnaires/po_1_tygodniu_i_na_koncu/js/questionnaires.js
+++ b/frontend/pages/questionnaires/po_1_tygodniu_i_na_koncu/js/questionnaires.js
@@ -6,6 +6,7 @@ export const qTypes = [
             {
                 name: "Ankieta zwrotna",
                 language: "pl",
+                id: 12,
                 typeId: "3.1",
                 type: "ankieta zwrotna",
                 description: "Celem ankiety jest zebranie informacji zwrotnej dotyczącej przeprowadzanego badania po to, aby móc ulepszyć procedury w przyszłości.",
@@ -37,6 +38,7 @@ export const qTypes = [
             {
                 name: "Ankieta zwrotna",
                 language: "pl",
+                id: 12,
                 typeId: "3.2",
                 type: "ankieta zwrotna",
                 description: "Celem ankiety jest zebranie informacji zwrotnej dotyczącej przeprowadzanego badania po to, aby móc ulepszyć procedury w przyszłości.",

--- a/frontend/pages/questionnaires/po_2_tygodniach/js/questionnaires.js
+++ b/frontend/pages/questionnaires/po_2_tygodniach/js/questionnaires.js
@@ -6,6 +6,7 @@ export const qTypes = [
             {
                 name: "Ankieta po 2 tygodniach badania",
                 language: "pl",
+                id: 19,
                 typeId: "6.1",
                 segments: [
                     {

--- a/frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js
+++ b/frontend/pages/questionnaires/przed_badaniem/js/questionnaires.js
@@ -6,6 +6,7 @@ export const qTypes = [
             {
                 name: "Kwestionariusz IPIP-BFM-20",
                 language: "pl",
+                id: 1,
                 typeId: "1.1",
                 type: "osobowość",
                 description: "Przeczytaj uważnie poniższe zdania, opisujące różne zachowania, uczucia i myśli ludzi. Zastanów się nad każdym z nich – w jakim stopniu opisuje ono również Ciebie takiego/taką, jakim/jaką zwykle jesteś? Ludzie są bardzo różni, więc nie ma tu dobrych ani złych odpowiedzi. Za każdym razem po prostu szczerze odpowiedz na pytanie, w jakim stopniu dane stwierdzenie opisuje Ciebie.",
@@ -184,6 +185,7 @@ export const qTypes = [
             {
                 name: "Demografia",
                 type: "demografia",
+                id: 2,
                 typeId: "1.1",
                 language: "pl",
                 segments: [
@@ -530,6 +532,7 @@ export const qTypes = [
             {
                 type: "humor",
                 name: "Humor Styles Questionnaire",
+                id: 3,
                 typeId: "1.1",
                 language: "pl",
                 segments: [

--- a/frontend/pages/questionnaires/przed_i_po_badaniu/js/questionnaires.js
+++ b/frontend/pages/questionnaires/przed_i_po_badaniu/js/questionnaires.js
@@ -1,3 +1,9 @@
+/* 
+    Each questionnaire has a unique id which corresponds to the utils/questionnaires.js and the backend
+
+
+*/
+
 export const qTypes = [
     {
         id: "2.1",
@@ -5,8 +11,9 @@ export const qTypes = [
         questionnaires: [
             {
                 name: "SWLS-A",
-                typeId: "2.2",
                 language: "pl",
+                id: 4,
+                typeId: "2.1",
                 type: "dobrostan: satysfakcja z życia",
                 segments: [
                     {
@@ -85,8 +92,9 @@ export const qTypes = [
             },
             {
                 name: "SPANE",
+                typeId: "2.1",
+                id: 5,
                 language: "pl",
-                typeId: "2.2",
                 type: "dobrostan: afekt",
                 segments: [
                     {
@@ -206,8 +214,9 @@ export const qTypes = [
             },
             {
                 name: "Skala Prosperowania",
+                typeId: "2.1",
+                id: 6,
                 language: "pl",
-                typeId: "2.2",
                 type: "dobrostan: skala prosperowania",
                 segments: [
                     {
@@ -306,105 +315,10 @@ export const qTypes = [
                 ]
             },
             {
-                name: "Kwestionariusz Zdrowia Pacjenta PHQ-9 (PHQ-9)",
-                language: "pl",
-                typeId: "2.2",
-                type: "depresja",
-                segments: [
-                    {
-                        scales: {
-                            description: "Patient Health Questionnaire, jest przeznaczony do przesiewowego wykrywania depresji, wykorzystywany jest we wstępnej diagnozie. Jak często w ciągu ostatnich 2 tygodni dokuczały panu/pani następujące problemy?",
-                            values: [
-                                {
-                                    value: 0,
-                                    text: "wcale nie dokuczały"
-                                },
-                                {
-                                    value: 1,
-                                    text: "kilka dni"
-                                },
-                                {
-                                    value: 2,
-                                    text: "więcej niż połowę dni"
-                                },
-                                {
-                                    value: 3,
-                                    text: "niemal codziennie"
-                                },
-                            ]
-                        },
-                        questions: [
-                            {
-                                type: "slider",
-                                text: "Niewielkie zainteresowanie lub odczuwanie przyjemności z wykonywania czynności.",
-                                min: 0,
-                                max: 3,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Uczucie smutku, przygnębienia lub beznadziejności.",
-                                min: 0,
-                                max: 3,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Kłopoty z zaśnięciem lub przerywany sen, albo zbyt długi sen.",
-                                min: 0,
-                                max: 3,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Uczucie zmęczenia lub brak energii.",
-                                min: 0,
-                                max: 3,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Brak apetytu lub przejadanie się.",
-                                min: 0,
-                                max: 3,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Poczucie niezadowolenia z siebie — lub uczucie, że jest się do niczego, albo że zawiódł/zawiodła Pan/Pani siebie lub rodzinę.",
-                                min: 0,
-                                max: 3,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Problemy ze skupieniem się na przykład przy czytaniu gazety lub oglądaniu telewizji.",
-                                min: 0,
-                                max: 3,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Poruszanie się lub mówienie tak wolno, że inni mogliby to zauważyć? Albo wręcz przeciwnie — niemożność usiedzenia w miejscu lub podenerwowanie powodujące ruchliwość znacznie większą niż zwykle.",
-                                min: 0,
-                                max: 3,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Myśli, że lepiej byłoby umrzeć, albo chęć zrobienia sobie jakiejś krzywdy.",
-                                min: 0,
-                                max: 3,
-                                value: -1
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
                 name: "Kwestionariusz PSS",
+                typeId: "2.1",
+                id: 8,
                 language: "pl",
-                typeId: "2.2",
                 type: "stres",
                 segments: [
                     {
@@ -509,193 +423,10 @@ export const qTypes = [
                 ]
             },
             {
-                name: "Physical Health Questionnaire",
-                language: "pl",
-                typeId: "2.2",
-                type: "zdrowie",
-                segments: [
-                    {
-                        scales: {
-                            description: "Poniższe punkty dotyczą tego, jak się Pan(i) czuł(a) fizycznie w ciągu ostatnich 4 tygodni. W ciągu ostatnich 4 tygodni...",
-                            values: [
-                                {
-                                    value: 1,
-                                    text: "Wcale"
-                                },
-                                {
-                                    value: 2,
-                                    text: "Rzadko"
-                                },
-                                {
-                                    value: 3,
-                                    text: "Raz na jakiś czas"
-                                },
-                                {
-                                    value: 4,
-                                    text: "Czasami"
-                                },
-                                {
-                                    value: 5,
-                                    text: "Dość często"
-                                },
-                                {
-                                    value: 6,
-                                    text: "Często"
-                                },
-                                {
-                                    value: 7,
-                                    text: "Cały czas"
-                                }
-                            ]
-                        },
-                        questions: [
-                            {
-                                type: "slider",
-                                text: "Jak często miałeś/aś trudności z zasypianiem w nocy?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak często budziłeś/aś się w nocy?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak często miałeś/aś koszmary senne lub niepokojące sny?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak często Twój sen był spokojny i niezakłócony?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak często miałeś/aś bóle głowy?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak często bolała Cię głowa, gdy wywierano się na Ciebie dużą presję, aby załatwić sprawy?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak często bolała Cię głowa, gdy byłeś/aś sfrustrowany/a, ponieważ sprawy nie ułożyły się tak, jak powinny, lub gdy byłeś/aś na kogoś zirytowany/a?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak często cierpiałeś/aś z powodu rozstroju żołądka (niestrawności)?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak często musiałeś/aś uważać na to, co jesz, aby uniknąć rozstroju żołądka?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak często miałeś/aś mdłości lub inne problemy żołądkowe?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak często miałeś/aś zaparcia lub cierpiałeś na biegunkę?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            },
-                            {
-                                type: "radio",
-                                text: "Ile razy miałeś/aś drobne przeziębienie (np. takie które sprawiło, że czułeś/aś się niekomfortowo, ale nie zatrzymało Cię ono w łóżku ani nie spowodowało, że opuściłeś/aś pracę)?",
-                                options: [
-                                    {
-                                        text: "0 razy"
-                                    },
-                                    {
-                                        text: "1-2 razy"
-                                    },
-                                    {
-                                        text: "3 razy"
-                                    },
-                                    {
-                                        text: "4 razy"
-                                    },
-                                    {
-                                        text: "5 razy"
-                                    },
-                                    {
-                                        text: "6 razy"
-                                    },
-                                    {
-                                        text: "7 razy"
-                                    }
-                                ]
-                            },
-                            {
-                                type: "radio",
-                                text: "Ile razy miałeś/aś infekcje dróg oddechowych, poważniejsze niż drobne przeziębienie (np. takie które 'rozłożyły' cię na łopatki - zapalenie oskrzeli, zapalenie zatok itp.)?",
-                                options: [
-                                    {
-                                        text: "0 razy"
-                                    },
-                                    {
-                                        text: "1-2 razy"
-                                    },
-                                    {
-                                        text: "3 razy"
-                                    },
-                                    {
-                                        text: "4 razy"
-                                    },
-                                    {
-                                        text: "5 razy"
-                                    },
-                                    {
-                                        text: "6 razy"
-                                    },
-                                    {
-                                        text: "7 razy"
-                                    }
-                                ]
-                            },
-                            {
-                                type: "slider",
-                                text: "Jak długo na ogół trwało przeziębienie lub grypa, które przechodziłeś/aś (dni)?",
-                                alternateText: "Jak długo na ogół trwało przeziębienie lub grypa, które przechodziłeś/aś?",
-                                min: 1,
-                                max: 7,
-                                value: -1
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
                 name: "List of RESS-EMA Items",
+                typeId: "2.1",
+                id: 10,
                 language: "pl",
-                typeId: "2.2",
                 type: "regulacja emocji",
                 segments: [
                     {
@@ -840,7 +571,8 @@ export const qTypes = [
             {
                 name: "PAQ",
                 language: "pl",
-                typeId: "2.2",
+                id: 11,
+                typeId: "2.1",
                 type: "alexytymia",
                 segments: [
                     {
@@ -933,6 +665,7 @@ export const qTypes = [
             {
                 name: "SWLS-A",
                 typeId: "2.2",
+                id: 4,
                 language: "pl",
                 type: "dobrostan: satysfakcja z życia",
                 segments: [
@@ -1014,6 +747,7 @@ export const qTypes = [
                 name: "SPANE",
                 language: "pl",
                 typeId: "2.2",
+                id: 5,
                 type: "dobrostan: afekt",
                 segments: [
                     {
@@ -1135,6 +869,7 @@ export const qTypes = [
                 name: "Skala Prosperowania",
                 language: "pl",
                 typeId: "2.2",
+                id: 6,
                 type: "dobrostan: skala prosperowania",
                 segments: [
                     {
@@ -1236,6 +971,7 @@ export const qTypes = [
                 name: "Kwestionariusz Zdrowia Pacjenta PHQ-9 (PHQ-9)",
                 language: "pl",
                 typeId: "2.2",
+                id: 7,
                 type: "depresja",
                 segments: [
                     {
@@ -1332,6 +1068,7 @@ export const qTypes = [
                 name: "Kwestionariusz PSS",
                 language: "pl",
                 typeId: "2.2",
+                id: 8,
                 type: "stres",
                 segments: [
                     {
@@ -1439,6 +1176,7 @@ export const qTypes = [
                 name: "Physical Health Questionnaire",
                 language: "pl",
                 typeId: "2.2",
+                id: 9,
                 type: "zdrowie",
                 segments: [
                     {
@@ -1622,6 +1360,7 @@ export const qTypes = [
             {
                 name: "List of RESS-EMA Items",
                 language: "pl",
+                id: 10,
                 typeId: "2.2",
                 type: "regulacja emocji",
                 segments: [
@@ -1768,6 +1507,7 @@ export const qTypes = [
                 name: "PAQ",
                 language: "pl",
                 typeId: "2.2",
+                id: 11,
                 type: "alexytymia",
                 segments: [
                     {

--- a/frontend/pages/questionnaires/przed_i_po_badaniu/js/questionnaires.js
+++ b/frontend/pages/questionnaires/przed_i_po_badaniu/js/questionnaires.js
@@ -5,8 +5,8 @@ export const qTypes = [
         questionnaires: [
             {
                 name: "SWLS-A",
+                typeId: "2.2",
                 language: "pl",
-                typeId: "2.1",
                 type: "dobrostan: satysfakcja z życia",
                 segments: [
                     {
@@ -85,8 +85,8 @@ export const qTypes = [
             },
             {
                 name: "SPANE",
-                typeId: "2.1",
                 language: "pl",
+                typeId: "2.2",
                 type: "dobrostan: afekt",
                 segments: [
                     {
@@ -206,8 +206,8 @@ export const qTypes = [
             },
             {
                 name: "Skala Prosperowania",
-                typeId: "2.1",
                 language: "pl",
+                typeId: "2.2",
                 type: "dobrostan: skala prosperowania",
                 segments: [
                     {
@@ -306,9 +306,105 @@ export const qTypes = [
                 ]
             },
             {
-                name: "Kwestionariusz PSS",
-                typeId: "2.1",
+                name: "Kwestionariusz Zdrowia Pacjenta PHQ-9 (PHQ-9)",
                 language: "pl",
+                typeId: "2.2",
+                type: "depresja",
+                segments: [
+                    {
+                        scales: {
+                            description: "Patient Health Questionnaire, jest przeznaczony do przesiewowego wykrywania depresji, wykorzystywany jest we wstępnej diagnozie. Jak często w ciągu ostatnich 2 tygodni dokuczały panu/pani następujące problemy?",
+                            values: [
+                                {
+                                    value: 0,
+                                    text: "wcale nie dokuczały"
+                                },
+                                {
+                                    value: 1,
+                                    text: "kilka dni"
+                                },
+                                {
+                                    value: 2,
+                                    text: "więcej niż połowę dni"
+                                },
+                                {
+                                    value: 3,
+                                    text: "niemal codziennie"
+                                },
+                            ]
+                        },
+                        questions: [
+                            {
+                                type: "slider",
+                                text: "Niewielkie zainteresowanie lub odczuwanie przyjemności z wykonywania czynności.",
+                                min: 0,
+                                max: 3,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Uczucie smutku, przygnębienia lub beznadziejności.",
+                                min: 0,
+                                max: 3,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Kłopoty z zaśnięciem lub przerywany sen, albo zbyt długi sen.",
+                                min: 0,
+                                max: 3,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Uczucie zmęczenia lub brak energii.",
+                                min: 0,
+                                max: 3,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Brak apetytu lub przejadanie się.",
+                                min: 0,
+                                max: 3,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Poczucie niezadowolenia z siebie — lub uczucie, że jest się do niczego, albo że zawiódł/zawiodła Pan/Pani siebie lub rodzinę.",
+                                min: 0,
+                                max: 3,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Problemy ze skupieniem się na przykład przy czytaniu gazety lub oglądaniu telewizji.",
+                                min: 0,
+                                max: 3,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Poruszanie się lub mówienie tak wolno, że inni mogliby to zauważyć? Albo wręcz przeciwnie — niemożność usiedzenia w miejscu lub podenerwowanie powodujące ruchliwość znacznie większą niż zwykle.",
+                                min: 0,
+                                max: 3,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Myśli, że lepiej byłoby umrzeć, albo chęć zrobienia sobie jakiejś krzywdy.",
+                                min: 0,
+                                max: 3,
+                                value: -1
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                name: "Kwestionariusz PSS",
+                language: "pl",
+                typeId: "2.2",
                 type: "stres",
                 segments: [
                     {
@@ -413,9 +509,193 @@ export const qTypes = [
                 ]
             },
             {
-                name: "List of RESS-EMA Items",
-                typeId: "2.1",
+                name: "Physical Health Questionnaire",
                 language: "pl",
+                typeId: "2.2",
+                type: "zdrowie",
+                segments: [
+                    {
+                        scales: {
+                            description: "Poniższe punkty dotyczą tego, jak się Pan(i) czuł(a) fizycznie w ciągu ostatnich 4 tygodni. W ciągu ostatnich 4 tygodni...",
+                            values: [
+                                {
+                                    value: 1,
+                                    text: "Wcale"
+                                },
+                                {
+                                    value: 2,
+                                    text: "Rzadko"
+                                },
+                                {
+                                    value: 3,
+                                    text: "Raz na jakiś czas"
+                                },
+                                {
+                                    value: 4,
+                                    text: "Czasami"
+                                },
+                                {
+                                    value: 5,
+                                    text: "Dość często"
+                                },
+                                {
+                                    value: 6,
+                                    text: "Często"
+                                },
+                                {
+                                    value: 7,
+                                    text: "Cały czas"
+                                }
+                            ]
+                        },
+                        questions: [
+                            {
+                                type: "slider",
+                                text: "Jak często miałeś/aś trudności z zasypianiem w nocy?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak często budziłeś/aś się w nocy?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak często miałeś/aś koszmary senne lub niepokojące sny?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak często Twój sen był spokojny i niezakłócony?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak często miałeś/aś bóle głowy?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak często bolała Cię głowa, gdy wywierano się na Ciebie dużą presję, aby załatwić sprawy?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak często bolała Cię głowa, gdy byłeś/aś sfrustrowany/a, ponieważ sprawy nie ułożyły się tak, jak powinny, lub gdy byłeś/aś na kogoś zirytowany/a?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak często cierpiałeś/aś z powodu rozstroju żołądka (niestrawności)?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak często musiałeś/aś uważać na to, co jesz, aby uniknąć rozstroju żołądka?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak często miałeś/aś mdłości lub inne problemy żołądkowe?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak często miałeś/aś zaparcia lub cierpiałeś na biegunkę?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            },
+                            {
+                                type: "radio",
+                                text: "Ile razy miałeś/aś drobne przeziębienie (np. takie które sprawiło, że czułeś/aś się niekomfortowo, ale nie zatrzymało Cię ono w łóżku ani nie spowodowało, że opuściłeś/aś pracę)?",
+                                options: [
+                                    {
+                                        text: "0 razy"
+                                    },
+                                    {
+                                        text: "1-2 razy"
+                                    },
+                                    {
+                                        text: "3 razy"
+                                    },
+                                    {
+                                        text: "4 razy"
+                                    },
+                                    {
+                                        text: "5 razy"
+                                    },
+                                    {
+                                        text: "6 razy"
+                                    },
+                                    {
+                                        text: "7 razy"
+                                    }
+                                ]
+                            },
+                            {
+                                type: "radio",
+                                text: "Ile razy miałeś/aś infekcje dróg oddechowych, poważniejsze niż drobne przeziębienie (np. takie które 'rozłożyły' cię na łopatki - zapalenie oskrzeli, zapalenie zatok itp.)?",
+                                options: [
+                                    {
+                                        text: "0 razy"
+                                    },
+                                    {
+                                        text: "1-2 razy"
+                                    },
+                                    {
+                                        text: "3 razy"
+                                    },
+                                    {
+                                        text: "4 razy"
+                                    },
+                                    {
+                                        text: "5 razy"
+                                    },
+                                    {
+                                        text: "6 razy"
+                                    },
+                                    {
+                                        text: "7 razy"
+                                    }
+                                ]
+                            },
+                            {
+                                type: "slider",
+                                text: "Jak długo na ogół trwało przeziębienie lub grypa, które przechodziłeś/aś (dni)?",
+                                alternateText: "Jak długo na ogół trwało przeziębienie lub grypa, które przechodziłeś/aś?",
+                                min: 1,
+                                max: 7,
+                                value: -1
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                name: "List of RESS-EMA Items",
+                language: "pl",
+                typeId: "2.2",
                 type: "regulacja emocji",
                 segments: [
                     {
@@ -560,7 +840,7 @@ export const qTypes = [
             {
                 name: "PAQ",
                 language: "pl",
-                typeId: "2.1",
+                typeId: "2.2",
                 type: "alexytymia",
                 segments: [
                     {

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -30,6 +30,12 @@ const DATE_FORMAT = "DD-MM-YYYY HH:mm:ss"
 const DATE_ONLY_FORMAT = "DD-MM-YYYY"
 const SERVER_DATE_FORMAT = "YYYY-MM-DDTHH:mm:ss"
 
+/*
+    Each questionnaire type has a list of questionnaire ids that corresponds to it. 
+    The questionnaires for each type are listed in frontend/pages/questionnaires/{key}/questionnaires.js
+    For example, the questionnaires for type 1.1 are listed in frontend/pages/questionnaires/przed_badaniem/questionnaires.js
+*/
+
 export const qCategories = [
     {
         id: "1",

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -397,6 +397,7 @@ export function getQuestionnairesToShow(firstQuestionnaireEverStr) {
         console.error(error)
     }
 
+
     return toShow
 }
 

--- a/frontend/utils/questionnaires.js
+++ b/frontend/utils/questionnaires.js
@@ -53,7 +53,7 @@ export const qCategories = [
                 id: "2.1",
                 name: "Przed i po badaniu (przed badaniem)",
                 count: 8,
-                questionnaires: [4, 5, 6, 7, 8, 9, 10, 11]
+                questionnaires: [4, 5, 6, 8, 10, 11]
             },
             {
                 id: "2.2",


### PR DESCRIPTION
Issues fixed with this PR:
Some of the przed_i_po_badaniu questionnaires are deleted but they still exist in the settings, so this PR deleted those in the settings as well. The incomplete deletion may cause users who has not finished their questionnaires before deletion to get prompts to finish the inexist questionnaires forever, which is quite minor, but might annoy users. 
As for now this PR might not be needed, but should there be problems with the przed_i_po_badaniu questionnaire, this PR might fix it. It may also serve as documentation. 

What's changed: 
- `frontend/components/auth/FormLogin.vue`: added more time to set filled questionnaires 
- `frontend/components/questionnaires/form/SliderInput.vue`: fix alignment warnings, which may appear on `console` when we are running the code on `yarn dev`
- `frontend/pages/questionnaires/*/js/questionnaires.js`: added the ids
- `frontend/utils/questionnaires.js`: deleted the deleted questionnaire ids from the questionnaire settings
